### PR TITLE
feat: add M5StickC Plus2 platform support

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,9 @@
 
 A tiny standalone device that shows your [Claude Code](https://docs.anthropic.com/en/docs/claude-code) rate-limit usage in real time. Polls the Anthropic API and displays your 5-hour and 7-day usage windows, reset countdowns, signal strength, and battery level.
 
-Supports two boards:
+Supports three boards:
 - **M5StickC Plus** (ESP32-PICO, 240x135 LCD)
+- **M5StickC Plus2** (ESP32-PICO-V3-02, 240x135 LCD)
 - **LilyGo T-Display S3** (ESP32-S3, 320x170 LCD)
 
 <p align="center">
@@ -23,11 +24,12 @@ Supports two boards:
 
 ## Hardware
 
-Either of these boards:
+Use one of these supported boards:
 
 | Board | MCU | Display | Battery | Buy |
 | ----- | --- | ------- | ------- | --- |
 | M5StickC Plus | ESP32-PICO | 1.14" 240x135 | 120 mAh | [m5stack.com](https://shop.m5stack.com/products/m5stickc-plus-esp32-pico-mini-iot-development-kit) |
+| M5StickC Plus2 | ESP32-PICO-V3-02 | 1.14" 240x135 | 200 mAh | [m5stack.com](https://shop.m5stack.com/products/m5stickc-plus2-esp32-mini-iot-development-kit) |
 | LilyGo T-Display S3 | ESP32-S3 | 1.9" 320x170 | 1300 mAh | [lilygo.cc](https://lilygo.cc/products/t-display-s3) |
 
 Plus any USB-C cable for flashing and power.
@@ -58,6 +60,10 @@ cd claude-usage-stick
 # M5StickC Plus
 pio run -e m5stick-cplus -t upload
 pio run -e m5stick-cplus -t uploadfs
+
+# M5StickC Plus2
+pio run -e m5stick-cplus2 -t upload
+pio run -e m5stick-cplus2 -t uploadfs
 
 # — or — LilyGo T-Display S3
 pio run -e tdisplay-s3 -t upload

--- a/platformio.ini
+++ b/platformio.ini
@@ -26,7 +26,7 @@ board_build.filesystem = spiffs
 board_build.partitions = default.csv
 
 lib_deps =
-    M5Unified=https://github.com/m5stack/M5Unified
+    m5stack/M5Unified@0.1.15
     bblanchon/ArduinoJson@^7.0.0
 
 build_flags =

--- a/platformio.ini
+++ b/platformio.ini
@@ -16,6 +16,25 @@ build_flags =
     -DARDUINO_M5STICK_C_PLUS
     -DCORE_DEBUG_LEVEL=1
 
+[env:m5stick-cplus2]
+platform = espressif32@6.9.0
+board = m5stick-c
+framework = arduino
+monitor_speed = 115200
+upload_speed = 1500000
+board_build.filesystem = spiffs
+board_build.partitions = default.csv
+
+lib_deps =
+    M5Unified=https://github.com/m5stack/M5Unified
+    bblanchon/ArduinoJson@^7.0.0
+
+build_flags =
+    -DBOARD_M5STICK_C_PLUS2
+    -DBOARD_HAS_PSRAM
+    -mfix-esp32-psram-cache-issue
+    -DCORE_DEBUG_LEVEL=1
+
 [env:tdisplay-s3]
 platform = espressif32@6.9.0
 board = lilygo-t-display-s3

--- a/src/hal.cpp
+++ b/src/hal.cpp
@@ -51,6 +51,43 @@ void halSetBrightness(uint8_t level) {
     ledcWrite(0, vals[level]);
 }
 
+#elif defined(BOARD_M5STICK_C_PLUS2)
+
+#define HOLD_PIN 4
+
+void halInit() {
+    pinMode(HOLD_PIN, OUTPUT);
+    digitalWrite(HOLD_PIN, HIGH);
+
+    auto cfg = M5.config();
+    M5.begin(cfg);
+}
+
+void halUpdate() {
+    M5.update();
+}
+
+bool halBtnAWasPressed() { return M5.BtnA.wasPressed(); }
+bool halBtnBWasPressed() { return M5.BtnB.wasPressed(); }
+bool halBtnAIsPressed()  { return M5.BtnA.isPressed(); }
+bool halBtnBIsPressed()  { return M5.BtnB.isPressed(); }
+
+int halBatPercent() {
+    int pct = M5.Power.getBatteryLevel();
+    if (pct >= 0 && pct <= 100) {
+        return pct;
+    }
+
+    const int mv = M5.Power.getBatteryVoltage();
+    const float v = mv / 1000.0f;
+    return constrain((int)((v - 3.3f) / 0.85f * 100), 0, 100);
+}
+
+void halSetBrightness(uint8_t level) {
+    static const uint8_t vals[] = {0, 64, 160, 255};
+    M5.Display.setBrightness(vals[level]);
+}
+
 #else // M5StickC Plus
 
 void halInit() {

--- a/src/hal.h
+++ b/src/hal.h
@@ -4,8 +4,14 @@
 #ifdef BOARD_TDISPLAY_S3
   #include <TFT_eSPI.h>
   extern TFT_eSPI lcd;
+#elif defined(BOARD_M5STICK_C_PLUS2)
+  #include <M5Unified.h>
+  #define lcd M5.Display
 #else
   #include <M5StickCPlus.h>
+  #ifdef lcd
+    #undef lcd
+  #endif
   #define lcd M5.Lcd
 #endif
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 /*
  * Claude Code Usage Monitor — Standalone WiFi
- * Supports: M5StickC Plus, LilyGo T-Display S3
+ * Supports: M5StickC Plus, M5StickC Plus2, LilyGo T-Display S3
  *
  * Button A: cycle digit (PIN) / cycle brightness (dashboard)
  * Button B: confirm digit (PIN) / force refresh (dashboard)


### PR DESCRIPTION
- Add dedicated PlatformIO env for M5StickC Plus2
- Implement Plus2 HAL path via M5Unified (buttons, battery, brightness)
- Set HOLD (GPIO4) high during init for Plus2 power behavior
- Update README to document 3 supported boards and Plus2 flash commands