### PR TITLE
Add support for TTGO T-Display ESP32 (1.14" ST7789)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,11 +2,12 @@
 
 A tiny standalone device that shows your [Claude Code](https://docs.anthropic.com/en/docs/claude-code) rate-limit usage in real time. Polls the Anthropic API and displays your 5-hour and 7-day usage windows, reset countdowns, signal strength, and battery level.
 
-Supports four boards:
+Supports six boards:
 - **M5StickC Plus** (ESP32-PICO, 240x135 LCD)
 - **M5StickC Plus2** (ESP32-PICO-V3-02, 240x135 LCD)
 - **LilyGo T-Display S3** (ESP32-S3, 320x170 LCD)
 - **LilyGo T-Display S3 AMOLED** 1.91" (ESP32-S3, 240x536 RM67162 AMOLED — H712/H713/H705/H681/H717)
+- **TTGO T-Display ESP32** (ESP32, 1.14" 135x240 ST7789 LCD)
 - **ESP32-C3-OLED** (ESP32-C3, 0.42" 72x40 OLED) — breadboard-friendly; bring your own buttons
 
 <p align="center">
@@ -38,6 +39,7 @@ Use one of these supported boards:
 | M5StickC Plus2 | ESP32-PICO-V3-02 | 1.14" 240x135 | 200 mAh | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c3jkKlNj) |
 | LilyGo T-Display S3 | ESP32-S3 | 1.9" 320x170 LCD | 1300 mAh | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
 | LilyGo T-Display S3 AMOLED (1.91") | ESP32-S3 | 1.91" 240x536 AMOLED | varies | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c3XNB9Hx) |
+| TTGO T-Display ESP32 | ESP32 | 1.14" 240x135 LCD | external (JST 1.25mm) | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c32HlGQ1) |
 | ESP32-C3-OLED | ESP32-C3 | 0.42" 72x40 OLED | external | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c3JMxywv) |
 | M5Stack StickS3 | — | — | — | 🚧 In progress | [aliexpress.com](https://s.click.aliexpress.com/e/_c3ZsWHBB) |
 
@@ -112,6 +114,10 @@ pio run -e tdisplay-s3 -t uploadfs
 # LilyGo T-Display S3 AMOLED 1.91" (H712/H713/H705/H681/H717)
 pio run -e tdisplay-s3-amoled -t upload
 pio run -e tdisplay-s3-amoled -t uploadfs
+
+# TTGO T-Display ESP32 (1.14" ST7789 LCD)
+pio run -e tdisplay-esp32 -t upload
+pio run -e tdisplay-esp32 -t uploadfs
 
 # ESP32-C3-OLED
 pio run -e esp32c3-oled -t upload

--- a/platformio.ini
+++ b/platformio.ini
@@ -52,6 +52,40 @@ build_flags =
     -DBOARD_ESP32C3_OLED
     -DCORE_DEBUG_LEVEL=1
 
+[env:tdisplay-esp32]
+platform = espressif32@6.9.0
+board = lilygo-t-display
+framework = arduino
+monitor_speed = 115200
+upload_port = /dev/cu.usbserial-*
+upload_speed = 460800
+board_build.filesystem = spiffs
+board_build.partitions = default.csv
+
+lib_deps =
+    bodmer/TFT_eSPI@^2.5.0
+    bblanchon/ArduinoJson@^7.0.0
+
+build_flags =
+    -DBOARD_TDISPLAY_ESP32
+    -DUSER_SETUP_LOADED
+    -DST7789_DRIVER
+    -DTFT_WIDTH=135
+    -DTFT_HEIGHT=240
+    -DTFT_MOSI=19
+    -DTFT_SCLK=18
+    -DTFT_CS=5
+    -DTFT_DC=16
+    -DTFT_RST=23
+    -DTFT_BL=4
+    -DTFT_BACKLIGHT_ON=HIGH
+    -DSPI_FREQUENCY=40000000
+    -DLOAD_GLCD
+    -DLOAD_FONT2
+    -DLOAD_FONT4
+    -DLOAD_GFXFF
+    -DCORE_DEBUG_LEVEL=1
+
 [env:tdisplay-s3]
 platform = espressif32@6.9.0
 board = lilygo-t-display-s3

--- a/src/config.h
+++ b/src/config.h
@@ -23,6 +23,10 @@
   #define SCREEN_W              536
   #define SCREEN_H              240
   #define SCREEN_ROT            0
+#elif defined(BOARD_TDISPLAY_ESP32)
+  #define SCREEN_W              240
+  #define SCREEN_H              135
+  #define SCREEN_ROT            3
 #else
   #define SCREEN_W              240
   #define SCREEN_H              135

--- a/src/hal.cpp
+++ b/src/hal.cpp
@@ -111,6 +111,60 @@ void halFlush() {}
 
 void halClear(uint16_t color) { lcd.fillScreen(color); }
 
+#elif defined(BOARD_TDISPLAY_ESP32)
+
+// TTGO/LilyGo T-Display ESP32 (1.14" ST7789 135x240, 4-wire SPI).
+TFT_eSPI lcd;
+
+#define BTN_A_PIN  0    // also BOOT button; onboard pull-up, active-LOW
+#define BTN_B_PIN  35   // input-only pin (no internal pull); onboard pull-up, active-LOW
+#define BAT_ADC    34   // battery voltage via 2:1 divider
+#define ADC_EN     14   // drive HIGH to enable the battery divider
+#define BL_PIN     4
+
+static bool prevA = false, prevB = false;
+static bool tapA = false, tapB = false;
+
+void halInit() {
+    pinMode(ADC_EN, OUTPUT);
+    digitalWrite(ADC_EN, HIGH);
+    lcd.init();
+    pinMode(BTN_A_PIN, INPUT_PULLUP);
+    pinMode(BTN_B_PIN, INPUT);       // GPIO35 is input-only; relies on board pull-up
+    ledcSetup(0, 5000, 8);
+    ledcAttachPin(BL_PIN, 0);
+    ledcWrite(0, 200);
+}
+
+void halUpdate() {
+    bool a = !digitalRead(BTN_A_PIN);
+    bool b = !digitalRead(BTN_B_PIN);
+    tapA = (a && !prevA);
+    tapB = (b && !prevB);
+    prevA = a;
+    prevB = b;
+}
+
+bool halBtnAWasPressed() { bool r = tapA; tapA = false; return r; }
+bool halBtnBWasPressed() { bool r = tapB; tapB = false; return r; }
+bool halBtnAIsPressed()  { return !digitalRead(BTN_A_PIN); }
+bool halBtnBIsPressed()  { return !digitalRead(BTN_B_PIN); }
+
+int halBatPercent() {
+    uint16_t raw = analogRead(BAT_ADC);
+    float v = (raw / 4095.0f) * 3.3f * 2.0f;
+    return constrain((int)((v - 3.3f) / 0.85f * 100), 0, 100);
+}
+
+void halSetBrightness(uint8_t level) {
+    static const uint8_t vals[] = {0, 60, 160, 255};
+    ledcWrite(0, vals[level]);
+}
+
+void halFlush() {}
+
+void halClear(uint16_t color) { lcd.fillScreen(color); }
+
 #elif defined(BOARD_TDISPLAY_S3_AMOLED)
 
 // LilyGo T-Display S3 AMOLED (1.91" RM67162) — H712/H713/H705/H681/H717.

--- a/src/hal.h
+++ b/src/hal.h
@@ -10,6 +10,9 @@
 #elif defined(BOARD_TDISPLAY_S3)
   #include <TFT_eSPI.h>
   extern TFT_eSPI lcd;
+#elif defined(BOARD_TDISPLAY_ESP32)
+  #include <TFT_eSPI.h>
+  extern TFT_eSPI lcd;
 #elif defined(BOARD_TDISPLAY_S3_AMOLED)
   #include <LilyGo_AMOLED.h>
   #include <TFT_eSPI.h>


### PR DESCRIPTION
## Summary

Adds a sixth supported board: the classic **TTGO / LilyGo T-Display ESP32** — a plain ESP32 with a 1.14" 135×240 ST7789 LCD over 4-wire SPI, USB-C, two buttons, and a 2-pin JST 1.25mm LiPo connector. Widely available and cheap.

It closely mirrors the existing **T-Display S3** support, swapping the S3's 8-bit parallel bus for SPI and targeting the plain ESP32 (no native USB CDC). The `ui.cpp` TFT drawing path and all network/crypto/provisioning code are board-agnostic and required no changes.

Buy link: https://s.click.aliexpress.com/e/_c32HlGQ1

## Changes

- **`platformio.ini`** — new `[env:tdisplay-esp32]` (`board = lilygo-t-display`, `TFT_eSPI` ST7789 SPI pins: MOSI19 / SCLK18 / CS5 / DC16 / RST23 / BL4). Upload speed is `460800` — `921600` reliably fails mid-transfer on these CH340/CP210x clones.
- **`src/config.h`** — `SCREEN_W/H` 240×135, `SCREEN_ROT 3` branch (keeps the board out of the M5Stick `#else`).
- **`src/hal.h` / `src/hal.cpp`** — `BOARD_TDISPLAY_ESP32` HAL block: buttons GPIO0 / GPIO35 (active-LOW; GPIO35 is input-only and uses the board's external pull-up), battery ADC on GPIO34 with `ADC_EN` (GPIO14) driven HIGH, LEDC backlight on GPIO4.
- **`README.md`** — board added to the intro list, hardware table (with buy link), and flashing commands; corrected the stale "four boards" count to six.

## Pinout (standard TTGO T-Display)

| Function | GPIO |
| --- | --- |
| MOSI / SCLK | 19 / 18 |
| CS / DC / RST | 5 / 16 / 23 |
| Backlight | 4 |
| Button A / B | 0 / 35 |
| Battery ADC / ADC_EN | 34 / 14 |

## Testing

- `pio run -e tdisplay-esp32` compiles clean (ESP32-D0WDQ6, ST7789 SPI driver).
- Flashed firmware + filesystem to real hardware over `/dev/cu.usbserial-*`.
- Verified on-device: boots cleanly into the captive-portal setup screen (`ClaudeMonitor-XXXX` AP + WPA password shown on the LCD); display renders correctly in landscape with correct colors (no `invertDisplay` needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)