### PR TITLE
feat: add support for GeekMagic SmallTV (ESP8266, 240x240 ST7789)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A tiny standalone device that shows your [Claude Code](https://docs.anthropic.com/en/docs/claude-code) rate-limit usage in real time. Polls the Anthropic API and displays your 5-hour and 7-day usage windows, reset countdowns, signal strength, and battery level.
 
-Supports seven boards:
+Supports eight boards:
 - **M5StickC Plus** (ESP32-PICO, 240x135 LCD)
 - **M5StickC Plus2** (ESP32-PICO-V3-02, 240x135 LCD)
 - **LilyGo T-Display S3** (ESP32-S3, 320x170 LCD)
@@ -10,6 +10,7 @@ Supports seven boards:
 - **LilyGo T-Display S3 AMOLED** 1.91" (ESP32-S3, 240x536 RM67162 AMOLED — H712/H713/H705/H681/H717)
 - **TTGO T-Display ESP32** (ESP32, 1.14" 135x240 ST7789 LCD)
 - **ESP32-C3-OLED** (ESP32-C3, 0.42" 72x40 OLED) — breadboard-friendly; bring your own buttons
+- **GeekMagic SmallTV / GIF.TV** (ESP8266 ESP-12F, 1.5" 240x240 ST7789) — USB-powered, no buttons; unlocks over the web
 
 <p align="center">
   <img src="docs/boot.jpg" width="260" alt="Boot screen">
@@ -43,6 +44,7 @@ Use one of these supported boards:
 | LilyGo T-Display S3 AMOLED (1.91") | ESP32-S3 | 1.91" 240x536 AMOLED | varies | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c3XNB9Hx) |
 | TTGO T-Display ESP32 | ESP32 | 1.14" 240x135 LCD | external (JST 1.25mm) | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c32HlGQ1) |
 | ESP32-C3-OLED | ESP32-C3 | 0.42" 72x40 OLED | external | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c3JMxywv) |
+| GeekMagic SmallTV / GIF.TV | ESP8266 ESP-12F | 1.5" 240x240 ST7789 | none (USB) | ✅ | [aliexpress.com](https://s.click.aliexpress.com/e/_c2yv5tX3) |
 | M5Stack StickS3 | — | — | — | 🚧 In progress | [aliexpress.com](https://s.click.aliexpress.com/e/_c3ZsWHBB) |
 
 > **T8 ESP32-S2 notes**
@@ -51,6 +53,15 @@ Use one of these supported boards:
 > - **One button, two roles** — the board exposes only the onboard **BOOT** button (GPIO0), so controls are split by press length: **short tap = Button A** (cycle digit / brightness), **long press = Button B** (confirm digit / refresh).
 > - **No on-boot factory reset** — GPIO0 is a strapping pin, so "hold A+B on boot" is unavailable; re-flash to wipe NVS.
 > - **No battery readout** — there's no confirmed battery-sense ADC, so battery percentage isn't shown.
+
+> **GeekMagic SmallTV notes**
+>
+> - **First ESP8266 board** — the firmware's ESP32-only pieces (NVS, mbedTLS crypto, `WiFiClientSecure`, LEDC PWM) are reimplemented behind `#ifdef ESP8266`: BearSSL TLS, the rweather/Crypto AES-GCM, and a LittleFS-backed config store. The platform glue lives in `src/compat_esp8266.*`.
+> - **No buttons → web PIN unlock** — the per-boot PIN is entered in a browser, not on buttons. The device joins WiFi, shows an unlock URL (`http://claude-tv.local`) on its screen, and waits for the PIN before loading the dashboard.
+> - **No on-boot factory reset** — with no buttons, "hold A+B" is unavailable; re-flash to wipe.
+> - **Flash via UART pads** — most units' USB-C is power-only, so flashing needs a 3.3 V USB-to-UART adapter on the pads (see below). Stock firmware can't be OTA-replaced.
+> - **TLS is tight** — the ESP8266 has ~40 KB free heap and runs the api.anthropic.com handshake itself; this is the least-proven part. **Not yet verified on hardware.**
+> - **Verify the pinout** — GeekMagic revisions vary; confirm the SPI/backlight pins, rotation, and color inversion against your PCB.
 
 Plus any USB-C cable for flashing and power.
 
@@ -84,6 +95,32 @@ Any module that outputs a logic-HIGH signal when touched works as a drop-in repl
 <p align="center">
   <img src="docs/esp32-c3-oled-touch-buttons.jpg" width="500" alt="ESP32-C3-OLED wired with capacitive touch sensors on GPIO 3 and GPIO 7">
 </p>
+
+### GeekMagic SmallTV wiring & flashing
+
+The GeekMagic's USB-C port is **power-only** on most units (no onboard USB-serial chip), so the
+first flash goes through the 6 UART pads on the PCB with a 3.3 V USB-to-UART adapter
+(CP2102/CH340/FT232). Verify the silkscreen before wiring.
+
+| Pad   | Connect to       | Notes |
+| ----- | ---------------- | ----- |
+| GND   | adapter GND      | |
+| TXD0  | adapter RX       | |
+| RXD0  | adapter TX       | |
+| 3V3   | adapter 3V3      | do **not** also power 5 V via USB-C at the same time |
+| GPIO0 | GND on power-up  | hold low while powering on to enter flash mode |
+| RST   | pulse to GND     | optional reset |
+
+The pads have no DTR/RTS auto-reset, so enter the bootloader manually each time: hold GPIO0 to
+GND, power-cycle, then release. **Back up the stock firmware first** — it's your only way back:
+
+```bash
+esptool.py --port /dev/cu.usbserial-XXXX --baud 460800 read_flash 0x0 0x400000 stock_backup_4mb.bin
+```
+
+Display pins live in `platformio.ini` (HSPI `MOSI=13/SCLK=14`, `CS=15 DC=5 RST=4 BL=2`, ST7789
+240×240, rotation 2, `INVON`) and come from the hardware reference — confirm with a multimeter and
+adjust the build flags if your panel is mirrored, offset, or shows wrong colors.
 
 ## How It Works
 
@@ -135,6 +172,10 @@ pio run -e tdisplay-esp32 -t uploadfs
 # ESP32-C3-OLED
 pio run -e esp32c3-oled -t upload
 pio run -e esp32c3-oled -t uploadfs
+
+# GeekMagic SmallTV (ESP8266 — flash over USB-UART on the pads; see wiring above).
+# No uploadfs: config lives in LittleFS written at runtime, and the setup page is embedded.
+pio run -e geekmagic-smalltv -t upload
 ```
 
 > **AMOLED note:** the panel variant is auto-detected at runtime by the LilyGo_AMOLED library, so a single `tdisplay-s3-amoled` build covers all 1.91" AMOLED revisions (touch and non-touch, V1.0/V2.0/Black Shell). On touch-equipped variants (H705/H681/H717), tapping the screen anywhere acts as Button B.
@@ -155,6 +196,9 @@ pio run -e esp32c3-oled -t uploadfs
 5. Hit **Save & Reboot** — the device encrypts the token, stores it, and connects to your WiFi
 
 ### Daily use
+
+> **Button-less boards (GeekMagic SmallTV)** unlock differently: the device shows an unlock URL
+> (`http://claude-tv.local`) on its screen — open it in a browser and enter your PIN there.
 
 On each boot, enter your PIN using the device buttons:
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -195,3 +195,43 @@ build_flags =
     -DLOAD_FONT4
     -DLOAD_GFXFF
     -DCORE_DEBUG_LEVEL=1
+
+; GeekMagic SmallTV / GIF.TV (ESP8266 ESP-12F, 1.5" 240x240 ST7789, no buttons).
+; First ESP8266 target — the platform port lives behind `#ifdef ESP8266` (compat layer,
+; BearSSL TLS, rweather/Crypto instead of mbedTLS, LittleFS-backed config). The stock
+; USB-C is power-only on most units: flash via a 3.3V USB-UART adapter on the 6 pads
+; (GPIO0->GND on power-up for bootloader). Display uses the ESP8266 HSPI fixed pins
+; (MOSI=13/SCLK=14); CS/DC/RST/BL are from the hardware doc — VERIFY with a multimeter.
+[env:geekmagic-smalltv]
+platform = espressif8266@4.2.1
+board = esp12e
+framework = arduino
+monitor_speed = 115200
+upload_speed = 460800
+board_build.filesystem = littlefs
+board_build.ldscript = eagle.flash.4m1m.ld
+
+lib_deps =
+    bodmer/TFT_eSPI@^2.5.0
+    bblanchon/ArduinoJson@^7.0.0
+    rweather/Crypto@^0.4.0
+
+build_flags =
+    -DBOARD_GEEKMAGIC_SMALLTV
+    -DUSER_SETUP_LOADED
+    -DST7789_DRIVER
+    -DTFT_WIDTH=240
+    -DTFT_HEIGHT=240
+    -DTFT_MOSI=13
+    -DTFT_SCLK=14
+    -DTFT_CS=15
+    -DTFT_DC=5
+    -DTFT_RST=4
+    -DTFT_BL=2
+    -DTFT_INVERSION_ON
+    -DTFT_BACKLIGHT_ON=HIGH
+    -DSPI_FREQUENCY=40000000
+    -DLOAD_GLCD
+    -DLOAD_FONT2
+    -DLOAD_FONT4
+    -DLOAD_GFXFF

--- a/src/api.cpp
+++ b/src/api.cpp
@@ -1,8 +1,14 @@
 #include "api.h"
 #include "config.h"
 #include <Arduino.h>
-#include <WiFiClientSecure.h>
-#include <HTTPClient.h>
+#ifdef ESP8266
+  #include <ESP8266WiFi.h>
+  #include <WiFiClientSecureBearSSL.h>
+  #include <ESP8266HTTPClient.h>
+#else
+  #include <WiFiClientSecure.h>
+  #include <HTTPClient.h>
+#endif
 
 // GlobalSign Root CA — trust anchor for api.anthropic.com
 static const char* ROOT_CA = R"CA(
@@ -38,8 +44,19 @@ static const char* RL_HEADERS[] = {
 static const int RL_HEADER_COUNT = 4;
 
 bool fetchUsage(const char* token, UsageData& out) {
+#ifdef ESP8266
+    // ESP8266 BearSSL: ~40 KB free heap and the TLS RX buffer dominates it. 16 KB is
+    // the safe default for Cloudflare-fronted hosts (which usually don't negotiate
+    // MFLN); drop the RX size to 4096 to reclaim heap if your endpoint allows smaller
+    // fragments. Requires valid NTP time before the handshake (BearSSL checks cert dates).
+    static BearSSL::X509List ta(ROOT_CA);
+    BearSSL::WiFiClientSecure client;
+    client.setTrustAnchors(&ta);
+    client.setBufferSizes(16384, 512);
+#else
     WiFiClientSecure client;
     client.setCACert(ROOT_CA);
+#endif
 
     HTTPClient https;
     if (!https.begin(client, MESSAGES_ENDPOINT)) {

--- a/src/compat_esp8266.cpp
+++ b/src/compat_esp8266.cpp
@@ -1,0 +1,172 @@
+#include "compat_esp8266.h"
+#ifdef ESP8266
+
+#include <string.h>
+
+// ── LittleFS-backed config store (NVS replacement) ──────────────────────────
+// ESP8266 has no NVS `Preferences`. The full key set is small and fixed, so we
+// persist one packed struct and field-map each key. Writes flush immediately so
+// a power loss mid-session can't lose committed config.
+
+static const uint32_t CFG_MAGIC = 0xC0DECAFE;
+static const char*    CFG_PATH  = "/config.bin";
+
+struct ConfigStore {
+    uint32_t      magic;
+    char          ssid[33];
+    char          wifipass[65];
+    EncryptedBlob blob;
+    int32_t       poll_sec;
+    int32_t       brightness;
+    char          dev_name[33];
+    uint8_t       provisioned;
+};
+
+static ConfigStore g_cfg;
+static bool        g_loaded  = false;
+static bool        g_fsReady = false;
+
+static void ensureFs() {
+    if (g_fsReady) return;
+    if (!LittleFS.begin()) {   // unformatted on first run — format then mount
+        LittleFS.format();
+        LittleFS.begin();
+    }
+    g_fsReady = true;
+}
+
+static void loadStore() {
+    ensureFs();
+    memset(&g_cfg, 0, sizeof(g_cfg));
+    File f = LittleFS.open(CFG_PATH, "r");
+    if (f) {
+        if (f.size() == sizeof(g_cfg)) {
+            f.read((uint8_t*)&g_cfg, sizeof(g_cfg));
+        }
+        f.close();
+    }
+    if (g_cfg.magic != CFG_MAGIC) {        // absent / wrong-size / corrupt
+        memset(&g_cfg, 0, sizeof(g_cfg));
+        g_cfg.magic = CFG_MAGIC;           // valid-but-empty
+    }
+    g_loaded = true;
+}
+
+static void saveStore() {
+    ensureFs();
+    g_cfg.magic = CFG_MAGIC;
+    File f = LittleFS.open(CFG_PATH, "w");
+    if (f) {
+        f.write((const uint8_t*)&g_cfg, sizeof(g_cfg));
+        f.close();
+    }
+}
+
+bool Preferences::begin(const char* name, bool readOnly) {
+    (void)name;            // single namespace — name is ignored
+    _ro = readOnly;
+    loadStore();
+    return true;
+}
+
+void Preferences::end() { /* per-put write-through, nothing to flush */ }
+
+bool Preferences::clear() {
+    ensureFs();
+    LittleFS.remove(CFG_PATH);
+    memset(&g_cfg, 0, sizeof(g_cfg));
+    g_cfg.magic = CFG_MAGIC;
+    g_loaded = true;
+    return true;
+}
+
+size_t Preferences::putString(const char* key, const String& value) {
+    if (!g_loaded) loadStore();
+    char* dst = nullptr; size_t cap = 0;
+    if      (!strcmp(key, "ssid"))     { dst = g_cfg.ssid;     cap = sizeof(g_cfg.ssid); }
+    else if (!strcmp(key, "wifipass")) { dst = g_cfg.wifipass; cap = sizeof(g_cfg.wifipass); }
+    else if (!strcmp(key, "dev_name")) { dst = g_cfg.dev_name; cap = sizeof(g_cfg.dev_name); }
+    else return 0;
+    strlcpy(dst, value.c_str(), cap);
+    if (!_ro) saveStore();
+    return strlen(dst);
+}
+
+String Preferences::getString(const char* key, const char* defaultValue) {
+    if (!g_loaded) loadStore();
+    const char* v = nullptr;
+    if      (!strcmp(key, "ssid"))     v = g_cfg.ssid;
+    else if (!strcmp(key, "wifipass")) v = g_cfg.wifipass;
+    else if (!strcmp(key, "dev_name")) v = g_cfg.dev_name;
+    if (v && v[0]) return String(v);
+    return String(defaultValue);
+}
+
+size_t Preferences::putBytes(const char* key, const void* value, size_t len) {
+    if (!g_loaded) loadStore();
+    if (!strcmp(key, "blob")) {
+        size_t n = len < sizeof(g_cfg.blob) ? len : sizeof(g_cfg.blob);
+        memcpy(&g_cfg.blob, value, n);
+        if (!_ro) saveStore();
+        return n;
+    }
+    return 0;
+}
+
+size_t Preferences::getBytes(const char* key, void* buf, size_t maxLen) {
+    if (!g_loaded) loadStore();
+    if (!strcmp(key, "blob")) {
+        size_t n = maxLen < sizeof(g_cfg.blob) ? maxLen : sizeof(g_cfg.blob);
+        memcpy(buf, &g_cfg.blob, n);
+        return n;
+    }
+    return 0;
+}
+
+size_t Preferences::putBool(const char* key, bool value) {
+    if (!g_loaded) loadStore();
+    if (!strcmp(key, "provisioned")) {
+        g_cfg.provisioned = value ? 1 : 0;
+        if (!_ro) saveStore();
+        return 1;
+    }
+    return 0;
+}
+
+bool Preferences::getBool(const char* key, bool defaultValue) {
+    if (!g_loaded) loadStore();
+    if (!strcmp(key, "provisioned")) return g_cfg.provisioned != 0;
+    return defaultValue;
+}
+
+size_t Preferences::putInt(const char* key, int32_t value) {
+    if (!g_loaded) loadStore();
+    if      (!strcmp(key, "poll_sec"))   { g_cfg.poll_sec   = value; if (!_ro) saveStore(); return 4; }
+    else if (!strcmp(key, "brightness")) { g_cfg.brightness = value; if (!_ro) saveStore(); return 4; }
+    return 0;
+}
+
+int32_t Preferences::getInt(const char* key, int32_t defaultValue) {
+    if (!g_loaded) loadStore();
+    // A stored 0 means "never set" for these keys (poll_sec min is 30, brightness
+    // min is 1 in provisioning), so fall back to the caller's default.
+    if      (!strcmp(key, "poll_sec"))   return g_cfg.poll_sec   ? g_cfg.poll_sec   : defaultValue;
+    else if (!strcmp(key, "brightness")) return g_cfg.brightness ? g_cfg.brightness : defaultValue;
+    return defaultValue;
+}
+
+// ── Hardware glue ───────────────────────────────────────────────────────────
+
+void fillRandom(uint8_t* buf, size_t n) {
+    size_t i = 0;
+    while (i < n) {
+        uint32_t r = *(volatile uint32_t*)0x3FF20E44;  // ESP8266 hardware RNG (WDEV_HWRNG)
+        for (int b = 0; b < 4 && i < n; b++) { buf[i++] = (uint8_t)(r & 0xFF); r >>= 8; }
+    }
+}
+
+void getMac6(uint8_t mac[6]) {
+    WiFi.macAddress(mac);
+}
+
+#endif // ESP8266

--- a/src/compat_esp8266.h
+++ b/src/compat_esp8266.h
@@ -1,0 +1,58 @@
+#pragma once
+// ─────────────────────────────────────────────────────────────────────────────
+// ESP8266 platform-compatibility shim.
+//
+// Every other supported board is ESP32-family; the GeekMagic SmallTV is the lone
+// ESP8266 target. This header concentrates the platform glue so the shared source
+// files (main/provision/crypto/api) need only minimal `#ifdef ESP8266` include
+// swaps instead of being littered with platform branches:
+//
+//   • aliases ESP8266WebServer -> WebServer  (matches the ESP32 class name)
+//   • a tiny NVS-`Preferences`-compatible store backed by a LittleFS file
+//   • fillRandom()/getMac6() replacing esp_fill_random()/esp_efuse_mac_get_default()
+//
+// The whole header is inert on non-ESP8266 builds.
+// ─────────────────────────────────────────────────────────────────────────────
+#ifdef ESP8266
+
+#include <Arduino.h>
+#include <ESP8266WiFi.h>
+#include <ESP8266WebServer.h>
+#include <ESP8266HTTPClient.h>
+#include <ESP8266mDNS.h>
+#include <DNSServer.h>
+#include <LittleFS.h>
+#include "crypto.h"
+
+// ESP32 code uses the class name `WebServer`; on ESP8266 it's `ESP8266WebServer`
+// with an identical API (.on/.arg/.send/.sendHeader/.handleClient/.onNotFound).
+using WebServer = ESP8266WebServer;
+
+// Minimal subset of the ESP32 NVS `Preferences` API, backed by a single packed
+// struct persisted to LittleFS `/config.bin`. Only the fixed key set this firmware
+// actually stores is supported (field-mapped) — unknown keys return the default.
+class Preferences {
+public:
+    bool    begin(const char* name, bool readOnly = false);
+    void    end();
+    bool    clear();
+
+    size_t  putString(const char* key, const String& value);
+    String  getString(const char* key, const char* defaultValue = "");
+    size_t  putBytes(const char* key, const void* value, size_t len);
+    size_t  getBytes(const char* key, void* buf, size_t maxLen);
+    size_t  putBool(const char* key, bool value);
+    bool    getBool(const char* key, bool defaultValue = false);
+    size_t  putInt(const char* key, int32_t value);
+    int32_t getInt(const char* key, int32_t defaultValue = 0);
+
+private:
+    bool _ro = false;
+};
+
+// Hardware glue (defined in compat_esp8266.cpp), mirroring the ESP-IDF helpers the
+// shared code calls on ESP32.
+void fillRandom(uint8_t* buf, size_t n);   // ESP-IDF esp_fill_random() equivalent
+void getMac6(uint8_t mac[6]);              // esp_efuse_mac_get_default() equivalent
+
+#endif // ESP8266

--- a/src/config.h
+++ b/src/config.h
@@ -31,6 +31,10 @@
   #define SCREEN_W              240
   #define SCREEN_H              135
   #define SCREEN_ROT            3
+#elif defined(BOARD_GEEKMAGIC_SMALLTV)
+  #define SCREEN_W              240
+  #define SCREEN_H              240
+  #define SCREEN_ROT            2        // stock uses rotation 2 + INVON; verify on hardware
 #else
   #define SCREEN_W              240
   #define SCREEN_H              135

--- a/src/crypto.cpp
+++ b/src/crypto.cpp
@@ -1,9 +1,84 @@
 #include "crypto.h"
 #include "config.h"
+#include <string.h>
+
+#ifdef ESP8266
+// ── ESP8266: rweather/Crypto (the ESP8266 core ships BearSSL, not mbedTLS) ──────
+// AES-256-GCM + iterated SHA-256, byte-for-byte compatible with the mbedTLS path
+// below: same KDF (PIN+MAC salt, KDF_ROUNDS iterations) and same EncryptedBlob
+// layout, so a blob is portable across platforms.
+#include <SHA256.h>
+#include <GCM.h>
+#include <AES.h>
+
+// Hardware glue from compat_esp8266.cpp (esp_*-call replacements).
+void fillRandom(uint8_t* buf, size_t n);
+void getMac6(uint8_t mac[6]);
+
+void deriveKey(const char* pin, const uint8_t* salt, size_t saltLen, uint8_t* keyOut32) {
+    SHA256 h;
+    uint8_t hash[32];
+
+    h.reset();
+    h.update((const uint8_t*)pin, strlen(pin));
+    h.update(salt, saltLen);
+    h.finalize(hash, sizeof(hash));
+
+    for (int i = 1; i < KDF_ROUNDS; i++) {
+        h.reset();
+        h.update(hash, sizeof(hash));
+        h.finalize(hash, sizeof(hash));
+    }
+
+    memcpy(keyOut32, hash, 32);
+}
+
+bool encryptToken(const char* plaintext, const char* pin, EncryptedBlob& blob) {
+    size_t ptLen = strlen(plaintext);
+    if (ptLen > sizeof(blob.ciphertext)) return false;
+
+    getMac6(blob.salt);
+    fillRandom(blob.iv, sizeof(blob.iv));
+
+    uint8_t key[32];
+    deriveKey(pin, blob.salt, sizeof(blob.salt), key);
+
+    GCM<AES256> gcm;
+    bool ok = gcm.setKey(key, 32) && gcm.setIV(blob.iv, sizeof(blob.iv));
+    if (ok) {
+        gcm.encrypt(blob.ciphertext, (const uint8_t*)plaintext, ptLen);
+        gcm.computeTag(blob.tag, sizeof(blob.tag));
+    }
+
+    memset(key, 0, sizeof(key));
+    blob.len = ptLen;
+    return ok;
+}
+
+bool decryptToken(const EncryptedBlob& blob, const char* pin, char* plainOut, size_t plainMaxLen) {
+    if (blob.len > plainMaxLen - 1) return false;
+
+    uint8_t key[32];
+    deriveKey(pin, blob.salt, sizeof(blob.salt), key);
+
+    GCM<AES256> gcm;
+    bool ok = gcm.setKey(key, 32) && gcm.setIV(blob.iv, sizeof(blob.iv));
+    if (ok) {
+        gcm.decrypt((uint8_t*)plainOut, blob.ciphertext, blob.len);
+        ok = gcm.checkTag(blob.tag, sizeof(blob.tag));   // wrong PIN => tag mismatch
+    }
+
+    memset(key, 0, sizeof(key));
+    if (!ok) return false;
+    plainOut[blob.len] = '\0';
+    return true;
+}
+
+#else
+// ── ESP32: native mbedTLS ───────────────────────────────────────────────────
 #include "mbedtls/gcm.h"
 #include "mbedtls/sha256.h"
 #include "esp_system.h"
-#include <string.h>
 
 void deriveKey(const char* pin, const uint8_t* salt, size_t saltLen, uint8_t* keyOut32) {
     mbedtls_sha256_context ctx;
@@ -80,3 +155,5 @@ bool decryptToken(const EncryptedBlob& blob, const char* pin, char* plainOut, si
     plainOut[blob.len] = '\0';
     return true;
 }
+
+#endif

--- a/src/hal.cpp
+++ b/src/hal.cpp
@@ -344,6 +344,44 @@ void halFlush() {}
 
 void halClear(uint16_t color) { lcd.fillScreen(color); }
 
+#elif defined(BOARD_GEEKMAGIC_SMALLTV)
+
+// GeekMagic SmallTV / GIF.TV (ESP8266 ESP-12F, 1.5" 240x240 ST7789 on the HSPI bus).
+// No buttons and no battery: the button HAL is stubbed (the boot PIN is entered over
+// the web instead — see runWebUnlock), and battery reads return -1. Backlight is PWM'd
+// with analogWrite() since the ESP8266 has no LEDC peripheral. Pins come from the
+// hardware reference doc — VERIFY against your PCB revision with a multimeter.
+TFT_eSPI lcd;
+
+#define BL_PIN 2   // GPIO2 PWM backlight (also a boot strapping pin — must be HIGH at boot)
+
+void halInit() {
+    lcd.init();
+    // Rotation is applied by uiInit() (SCREEN_ROT); color inversion comes from the
+    // TFT_INVERSION_ON build flag (stock firmware uses INVON).
+    pinMode(BL_PIN, OUTPUT);
+    analogWriteRange(255);
+    analogWrite(BL_PIN, 200);
+}
+
+void halUpdate() {}   // no buttons to sample
+
+bool halBtnAWasPressed() { return false; }
+bool halBtnBWasPressed() { return false; }
+bool halBtnAIsPressed()  { return false; }
+bool halBtnBIsPressed()  { return false; }
+
+int halBatPercent() { return -1; }   // USB-powered, no battery sense
+
+void halSetBrightness(uint8_t level) {
+    static const uint8_t vals[] = {0, 60, 160, 255};
+    analogWrite(BL_PIN, vals[level]);
+}
+
+void halFlush() {}
+
+void halClear(uint16_t color) { lcd.fillScreen(color); }
+
 #else // M5StickC Plus
 
 void halInit() {

--- a/src/hal.h
+++ b/src/hal.h
@@ -25,6 +25,9 @@
 #elif defined(BOARD_M5STICK_C_PLUS2)
   #include <M5Unified.h>
   #define lcd M5.Display
+#elif defined(BOARD_GEEKMAGIC_SMALLTV)
+  #include <TFT_eSPI.h>
+  extern TFT_eSPI lcd;
 #else
   #include <M5StickCPlus.h>
   #ifdef lcd

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -13,13 +13,27 @@
  */
 
 #include "hal.h"
-#include <WiFi.h>
-#include <Preferences.h>
+#ifdef ESP8266
+  #include "compat_esp8266.h"   // ESP8266WiFi + Preferences shim + getMac6/fillRandom
+  #include "unlock.h"
+#else
+  #include <WiFi.h>
+  #include <Preferences.h>
+#endif
 #include "config.h"
 #include "crypto.h"
 #include "provision.h"
 #include "api.h"
 #include "ui.h"
+
+// Chip MAC + hardware RNG — ESP-IDF calls on ESP32, compat shims on ESP8266.
+#ifdef ESP8266
+static inline void chipMac(uint8_t* m)             { getMac6(m); }
+static inline void chipRandom(uint8_t* b, size_t n) { fillRandom(b, n); }
+#else
+static inline void chipMac(uint8_t* m)             { esp_efuse_mac_get_default(m); }
+static inline void chipRandom(uint8_t* b, size_t n) { esp_fill_random(b, n); }
+#endif
 
 static Preferences prefs;
 static char        token[256];
@@ -29,6 +43,8 @@ static int         pollMs     = DEFAULT_POLL_SEC * 1000;
 static uint8_t     brightness = DEFAULT_BRIGHTNESS;
 
 // ── PIN Entry (blocks until 4 digits confirmed) ────────
+// Button-driven; not used on button-less boards (ESP8266 GeekMagic unlocks over the web).
+#ifndef ESP8266
 static void enterPin(char* pinOut, int maxLen) {
     int digits[4] = {0, 0, 0, 0};
     int pos = 0;
@@ -44,6 +60,7 @@ static void enterPin(char* pinOut, int maxLen) {
     }
     snprintf(pinOut, maxLen, "%d%d%d%d", digits[0], digits[1], digits[2], digits[3]);
 }
+#endif
 
 // ── WiFi ───────────────────────────────────────────────
 static bool connectWiFi(const char* ssid, const char* pass) {
@@ -62,8 +79,15 @@ static bool connectWiFi(const char* ssid, const char* pass) {
 // ── Sync NTP for reset countdown display ───────────────
 static void syncTime() {
     configTime(0, 0, "pool.ntp.org", "time.nist.gov");
+#ifdef ESP8266
+    // ESP8266 has no getLocalTime(); poll until SNTP sets the clock (or time out).
+    // Valid time is required before the first TLS handshake — BearSSL checks cert dates.
+    time_t now = time(nullptr);
+    for (int i = 0; i < 100 && now < 1700000000; i++) { delay(100); now = time(nullptr); }
+#else
     struct tm t;
     getLocalTime(&t, 5000);
+#endif
 }
 
 // ── Fetch + draw ───────────────────────────────────────
@@ -123,7 +147,7 @@ void setup() {
         delay(400);
 
         uint8_t mac[6];
-        esp_efuse_mac_get_default(mac);
+        chipMac(mac);
         char apName[24];
         snprintf(apName, sizeof(apName), "ClaudeMonitor-%02X%02X", mac[4], mac[5]);
 
@@ -134,7 +158,7 @@ void setup() {
 #else
         static const char alphabet[] = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
         uint8_t rnd[8];
-        esp_fill_random(rnd, sizeof(rnd));
+        chipRandom(rnd, sizeof(rnd));
         char apPass[9];
         for (int i = 0; i < 8; i++) apPass[i] = alphabet[rnd[i] % (sizeof(alphabet) - 1)];
         apPass[8] = '\0';
@@ -158,6 +182,22 @@ void setup() {
 
     halSetBrightness(brightness);
 
+#ifdef ESP8266
+    // Button-less board: bring WiFi + time up first, then unlock the token via the web
+    // PIN page (the device shows the URL on its screen). WiFi creds aren't PIN-encrypted,
+    // so connecting before unlock is safe — and valid NTP time is needed for TLS anyway.
+    uiBootProgress(70, "Connecting WiFi...");
+    if (!connectWiFi(ssid.c_str(), pass.c_str())) {
+        uiError("WIFI FAILED", ssid.c_str());
+        delay(5000);
+        ESP.restart();
+    }
+
+    uiBootProgress(85, "Syncing time...");
+    syncTime();
+
+    runWebUnlock(blob, token, sizeof(token));   // blocks until the correct PIN decrypts
+#else
     uiBootProgress(60, "Enter PIN...");
     delay(300);
 
@@ -194,6 +234,7 @@ void setup() {
 
     uiBootProgress(90, "Syncing time...");
     syncTime();
+#endif
 
     uiBootProgress(95, "Fetching usage...");
     refresh();

--- a/src/provision.cpp
+++ b/src/provision.cpp
@@ -3,10 +3,14 @@
 #include "ui.h"
 #include "config.h"
 #include <Arduino.h>
-#include <WiFi.h>
-#include <WebServer.h>
+#ifdef ESP8266
+  #include "compat_esp8266.h"   // ESP8266WiFi + ESP8266WebServer (aliased WebServer) + Preferences shim
+#else
+  #include <WiFi.h>
+  #include <WebServer.h>
+  #include <Preferences.h>
+#endif
 #include <DNSServer.h>
-#include <Preferences.h>
 
 static WebServer  webServer(80);
 static DNSServer  dnsServer;

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -388,6 +388,38 @@ void uiSetupScreen(const char* apName, const char* apPass) {
     halFlush();
 }
 
+// Boot-time unlock prompt for button-less boards (e.g. GeekMagic SmallTV): the device
+// is on WiFi and hosts a one-field PIN page; the user opens it in a browser.
+void uiUnlockScreen(const char* url, const char* ip) {
+    halClear(C_BG);
+
+    lcd.fillRect(0, 0, SCREEN_W, SY(18), C_ACCENT);
+    lcd.setTextColor(C_TEXT, C_ACCENT);
+    lcd.setTextSize(TS(1));
+    lcd.setCursor(SX(6), SY(5));
+    lcd.print("LOCKED");
+
+    lcd.setTextColor(C_DIM, C_BG);
+    lcd.setTextSize(TS(1));
+    lcd.setCursor(SX(10), SY(30));
+    lcd.print("Enter PIN in browser:");
+
+    lcd.setTextColor(C_CYAN, C_BG);
+    lcd.setTextSize(TS(2));
+    lcd.setCursor(SX(10), SY(44));
+    lcd.print(url);
+
+    lcd.setTextColor(C_DIM, C_BG);
+    lcd.setTextSize(TS(1));
+    lcd.setCursor(SX(10), SY(70));
+    lcd.print("or visit");
+    lcd.setTextColor(C_CYAN, C_BG);
+    lcd.setTextSize(TS(2));
+    lcd.setCursor(SX(10), SY(82));
+    lcd.print(ip);
+    halFlush();
+}
+
 void uiPinScreen(int pos, const int digits[4]) {
     halClear(C_BG);
 

--- a/src/ui.h
+++ b/src/ui.h
@@ -4,6 +4,7 @@
 void uiInit();
 void uiBootProgress(int percent, const char* label);
 void uiSetupScreen(const char* apName, const char* apPass);
+void uiUnlockScreen(const char* url, const char* ip);  // button-less boards: web PIN unlock
 void uiPinScreen(int pos, const int digits[4]);
 void uiConnecting(const char* ssid, int attempt = 0);
 void uiDashboard(const UsageData& data, unsigned long lastFetchMs, int rssi, int batPct);

--- a/src/unlock.cpp
+++ b/src/unlock.cpp
@@ -1,0 +1,133 @@
+#include "unlock.h"
+#ifdef ESP8266
+
+#include "compat_esp8266.h"   // WebServer alias, Preferences shim, ESP8266 + mDNS includes
+#include "config.h"
+#include "ui.h"
+#include <Arduino.h>
+
+static WebServer            unlockServer(80);
+static const EncryptedBlob* s_blob     = nullptr;
+static char*                s_tokenOut  = nullptr;
+static size_t               s_tokenMax  = 0;
+static volatile bool        s_unlocked  = false;
+static int                  s_attempts  = 0;
+static int                  s_pendingLock = 0;   // seconds; enforced by the run loop
+
+static const char UNLOCK_HTML[] PROGMEM = R"rawhtml(<!DOCTYPE html>
+<html lang="en"><head><meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1,maximum-scale=1">
+<title>Claude Monitor - Unlock</title>
+<style>
+ *{box-sizing:border-box;margin:0;font-family:system-ui,-apple-system,sans-serif}
+ body{background:#191919;color:#e0e0e0;padding:8px;min-height:100vh}
+ .card{background:#252525;border:1px solid #3a3a3a;border-radius:12px;padding:18px;max-width:360px;margin:40px auto}
+ h1{color:#e8733a;font-size:1.3em;margin-bottom:4px}
+ .sub{color:#888;font-size:.85em;margin-bottom:14px}
+ input{width:100%;padding:10px;border:1px solid #3a3a3a;border-radius:8px;background:#191919;
+       color:#e0e0e0;font-size:1.5em;text-align:center;letter-spacing:10px;outline:0}
+ button{margin-top:12px;width:100%;padding:10px;border:none;border-radius:8px;background:#e8733a;
+        color:#191919;font-weight:700;font-size:1em;cursor:pointer}
+ #status{margin-top:8px;font-size:.9em;text-align:center;min-height:1.2em}
+ .err{color:#f66}
+</style></head>
+<body><div class="card">
+ <h1>Claude Usage Monitor</h1>
+ <p class="sub">Enter your PIN to unlock the dashboard.</p>
+ <form id="f">
+   <input id="pin" name="pin" type="password" inputmode="numeric" pattern="\d{4,8}"
+          minlength="4" maxlength="8" required autocomplete="off" placeholder="****">
+   <button type="submit">Unlock</button>
+   <div id="status"></div>
+ </form>
+</div>
+<script>
+document.getElementById('f').addEventListener('submit',async(e)=>{
+ e.preventDefault();const st=document.getElementById('status');st.className='';st.textContent='Unlocking...';
+ try{const r=await fetch('/unlock',{method:'POST',
+   headers:{'Content-Type':'application/x-www-form-urlencoded'},
+   body:new URLSearchParams(new FormData(e.target))});
+   const t=await r.text();
+   if(r.ok){st.textContent='Unlocked! The device is loading your dashboard.';}
+   else{st.className='err';st.textContent=t;}
+ }catch(x){st.className='err';st.textContent='Connection closed.';}
+});
+</script>
+</body></html>)rawhtml";
+
+static void handleRoot() {
+    unlockServer.send(200, "text/html", FPSTR(UNLOCK_HTML));
+}
+
+static void handleUnlock() {
+    String pin = unlockServer.arg("pin");
+    if (pin.length() < 4) {
+        unlockServer.send(400, "text/plain", "PIN must be at least 4 digits.");
+        return;
+    }
+
+    if (decryptToken(*s_blob, pin.c_str(), s_tokenOut, s_tokenMax)) {
+        unlockServer.send(200, "text/plain", "OK");
+        s_unlocked = true;
+        return;
+    }
+
+    s_attempts++;
+    if (s_attempts >= MAX_PIN_ATTEMPTS) {
+        unlockServer.send(403, "text/plain", "Too many attempts. Wiping credentials.");
+        delay(300);
+        Preferences prefs;
+        prefs.begin(NVS_NAMESPACE, false);
+        prefs.clear();
+        prefs.end();
+        uiError("MAX ATTEMPTS", "Wiping credentials...");
+        delay(2500);
+        ESP.restart();   // does not return
+    }
+
+    int lockSec = LOCKOUT_BASE_SEC * (1 << (s_attempts - 1));
+    if (lockSec > 3600) lockSec = 3600;
+    s_pendingLock = lockSec;   // run loop shows the countdown and gates retries
+
+    char msg[56];
+    snprintf(msg, sizeof(msg), "Wrong PIN. Wait %ds, then try again.", lockSec);
+    unlockServer.send(401, "text/plain", msg);
+}
+
+bool runWebUnlock(const EncryptedBlob& blob, char* tokenOut, size_t maxLen) {
+    s_blob        = &blob;
+    s_tokenOut    = tokenOut;
+    s_tokenMax    = maxLen;
+    s_unlocked    = false;
+    s_attempts    = 0;
+    s_pendingLock = 0;
+
+    MDNS.begin("claude-tv");
+    MDNS.addService("http", "tcp", 80);
+
+    unlockServer.on("/", HTTP_GET, handleRoot);
+    unlockServer.on("/unlock", HTTP_POST, handleUnlock);
+    unlockServer.onNotFound(handleRoot);
+    unlockServer.begin();
+
+    String ip = WiFi.localIP().toString();
+    uiUnlockScreen("claude-tv.local", ip.c_str());
+
+    while (!s_unlocked) {
+        unlockServer.handleClient();
+        MDNS.update();
+        if (s_pendingLock > 0) {
+            int sec = s_pendingLock;
+            s_pendingLock = 0;
+            uiLockout(s_attempts, MAX_PIN_ATTEMPTS, sec);   // blocks for the countdown
+            uiUnlockScreen("claude-tv.local", ip.c_str());
+        }
+        delay(2);
+    }
+
+    unlockServer.stop();
+    MDNS.end();
+    return true;
+}
+
+#endif // ESP8266

--- a/src/unlock.h
+++ b/src/unlock.h
@@ -1,0 +1,13 @@
+#pragma once
+#ifdef ESP8266
+#include <stddef.h>
+#include "crypto.h"
+
+// Button-less boot unlock for boards with no physical buttons (GeekMagic SmallTV).
+// The device is already on WiFi; this hosts a one-field PIN page (mDNS claude-tv.local)
+// and shows the URL on the TFT, blocking until the entered PIN decrypts the token into
+// tokenOut. Reuses the same lockout/attempt-cap policy as the button enterPin() path.
+// Returns true once unlocked (it does not return otherwise — wipes + reboots after the
+// attempt cap, mirroring main.cpp).
+bool runWebUnlock(const EncryptedBlob& blob, char* tokenOut, size_t maxLen);
+#endif


### PR DESCRIPTION
## What

Adds support for the **GeekMagic SmallTV / GIF.TV** (ESP8266 ESP-12F, 1.5" 240×240 ST7789, no buttons) — the project's first **ESP8266** target.

Every existing board is ESP32-family, so this isn't just a new board row: the ESP8266 has a different SDK, crypto stack, and TLS client, and no NVS or LEDC. The platform port lives behind `#ifdef ESP8266` so the proven ESP32 paths stay untouched.

## How

- **`platformio.ini`** — new `geekmagic-smalltv` env (`espressif8266`/`esp12e`, LittleFS, `rweather/Crypto`, ST7789 240×240 HSPI flags + `TFT_INVERSION_ON`).
- **`src/compat_esp8266.{h,cpp}`** (new) — concentrates the glue: ESP8266 includes, `using WebServer = ESP8266WebServer`, a `Preferences`-compatible store backed by a LittleFS `/config.bin` (NVS replacement), and `fillRandom()`/`getMac6()` replacing `esp_fill_random()`/`esp_efuse_mac_get_default()`.
- **`crypto.cpp`** — ESP8266 branch on `rweather/Crypto` (`SHA256` + `GCM<AES256>`); the ESP8266 core ships BearSSL, not mbedTLS. Same KDF (PIN + MAC salt, 10k rounds) and same `EncryptedBlob` layout.
- **`api.cpp`** — ESP8266 branch using `BearSSL::WiFiClientSecure` + `X509List(ROOT_CA)` + `setBufferSizes(16384, 512)`; reuses the same root CA and rate-limit header collection.
- **`main.cpp` / `provision.cpp`** — include/typedef swaps, `getMac6`/`fillRandom`, a portable NTP wait (no `getLocalTime` on ESP8266), and a boot reorder: WiFi + NTP come up **before** unlock.
- **`unlock.{h,cpp}` (new) + `uiUnlockScreen`** — button-less **web PIN unlock**: the device joins WiFi, hosts a one-field PIN page at `http://claude-tv.local` (URL shown on the TFT), and blocks until the PIN decrypts the token. Reuses the existing attempt-cap / lockout policy.
- **`hal.cpp` / `config.h` / `hal.h`** — board block: TFT init, `analogWrite` backlight (no LEDC), button/battery stubs.
- **README** — board row (+ buy link), notes, and a USB-UART flashing/wiring section.

## Decisions (from the planning discussion)

- **Token at rest → web PIN each boot** — keeps real PIN security, entered in a browser instead of on buttons.
- **API → direct standalone HTTPS** — no proxy.
- **Reconfigure → re-flash to reset** — no persistent admin; the unlock server is transient.

## Testing

- `pio run -e geekmagic-smalltv` ✅ (RAM 41.8% static, Flash 49%)
- `pio run -e tdisplay-esp32` ✅ and `pio run -e esp32c3-oled` ✅ — no regression to the ESP32 boards.
- ⚠️ **Not yet verified on hardware.** The board needs a 3.3 V USB-UART adapter on the pads (USB-C is power-only on most units). The main runtime risk is the ESP8266 doing TLS to api.anthropic.com within ~40 KB heap — if the handshake OOMs, drop the RX buffer (or fall back to the local proxy). NTP must be valid before the first fetch (BearSSL checks cert dates; boot order handles this). Verify the SPI/backlight pinout, rotation, and inversion against your PCB revision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
