### PR TITLE
docs: move the manual into a wiki, slim the README to a landing page

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,7 +18,9 @@
 ### New board port
 
 - [ ] 📸 Photo of the device **running this firmware** is attached above
-- [ ] `README.md` hardware table updated with this board (name, MCU, display, firmware version, PlatformIO env, buy link)
-- [ ] Board spec page added at `docs/<env>.md` (specs, flash commands, controls, quirks) — copy an existing page as a template
 - [ ] New `[env:...]` added to `platformio.ini`
-- [ ] (Optional, appreciated) photo added to the 📸 Gallery section in `README.md`
+- [ ] Board guide added at `wiki/<Board-Name>.md` (specs, flash commands, controls, quirks) — copy an existing page as a template
+- [ ] `wiki/Supported-Boards.md` table updated (name, MCU, display, firmware version, PlatformIO env, buy link)
+- [ ] `wiki/_Sidebar.md` links to the new guide
+- [ ] Board added to `BOARDS` and `BOARDS3D` in `web/src/build.py`, then `python3 web/src/build.py` re-run
+- [ ] Env added to the build matrix in `.github/workflows/pages.yml`

--- a/.github/workflows/wiki.yml
+++ b/.github/workflows/wiki.yml
@@ -1,0 +1,53 @@
+name: Publish wiki
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "wiki/**"
+      - ".github/workflows/wiki.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+concurrency:
+  group: wiki
+  cancel-in-progress: false
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Push wiki/ to the repository wiki
+        env:
+          TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          # GitHub only creates the .wiki.git repo once a first page exists, so a
+          # brand-new wiki has to be initialised by hand before this can push.
+          if ! git clone -q "https://x-access-token:${TOKEN}@github.com/${GITHUB_REPOSITORY}.wiki.git" wiki-repo; then
+            echo "::error::Wiki repository not found. Open https://github.com/${GITHUB_REPOSITORY}/wiki, click 'Create the first page', save anything, then re-run this workflow."
+            exit 1
+          fi
+
+          # mirror wiki/ exactly: drop pages that no longer exist upstream
+          find wiki-repo -maxdepth 1 -name '*.md' -delete
+          cp wiki/*.md wiki-repo/
+
+          cd wiki-repo
+          git config user.name "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add -A
+
+          if git diff --cached --quiet; then
+            echo "Wiki already up to date."
+            exit 0
+          fi
+
+          git commit -m "docs: sync wiki from ${GITHUB_SHA::7}"
+          git push
+          echo "Published $(ls *.md | wc -l | tr -d ' ') pages to the wiki."

--- a/README.md
+++ b/README.md
@@ -5,15 +5,11 @@
 **Your [Claude Code](https://docs.anthropic.com/en/docs/claude-code) rate limits, glanceable on a tiny ESP32 stick.**
 
 [![Web Flasher](https://img.shields.io/badge/⚡_web_flasher-flash_from_your_browser-D97757?style=flat-square)](https://oauramos.github.io/claude-usage-stick/)
-[![Firmware](https://img.shields.io/badge/firmware-🥭_Mango_(v2)-D97757?style=flat-square)](#-the-ui)
-[![PlatformIO](https://img.shields.io/badge/PlatformIO-ESP32_·_S2_·_S3_·_C3-FF7F00?style=flat-square&logo=platformio&logoColor=white)](https://platformio.org/)
-[![Framework](https://img.shields.io/badge/framework-Arduino-00979D?style=flat-square&logo=arduino&logoColor=white)](https://www.arduino.cc/)
-[![Boards](https://img.shields.io/badge/boards-8_supported-44cc11?style=flat-square)](#%EF%B8%8F-supported-hardware)
-[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](#-license)
-[![PRs](https://img.shields.io/badge/PRs-welcome-D97757?style=flat-square)](https://github.com/oauramos/claude-usage-stick/pulls)
+[![Wiki](https://img.shields.io/badge/docs-wiki-4c8eda?style=flat-square)](https://github.com/oauramos/claude-usage-stick/wiki)
+[![Boards](https://img.shields.io/badge/boards-8_supported-44cc11?style=flat-square)](https://github.com/oauramos/claude-usage-stick/wiki/Supported-Boards)
+[![License](https://img.shields.io/badge/license-MIT-blue?style=flat-square)](LICENSE)
 
 <img src="https://github.com/user-attachments/assets/c51c5a9e-5a3e-4c3e-97a8-d5a4c5a44263" width="720" alt="Claude Usage Stick — PIN unlock screen and usage dashboard on a LilyGo T-Display S3"/>
-
 
 *5-hour & 7-day usage windows · reset countdowns · model health mascots · PIN-encrypted token*
 
@@ -23,79 +19,13 @@
 
 A standalone desk gadget that polls the Anthropic API and shows your Claude Code rate-limit usage in real time — no computer, no app, no cloud. Flash it, connect it to WiFi from your phone, and it just sits there telling you how much runway you have left.
 
-## ✨ Features
+## Get one running
 
-- **Live usage bars** for the 5-hour and 7-day rate-limit windows
-- **Reset countdowns** so you know when capacity frees up
-- **Model status** *(Mango)* — Haiku / Sonnet / Opus / Fable health from [status.claude.com](https://status.claude.com), shown as blinking Clawd mascots; a downed model turns gray with X eyes
-- **PIN-protected** — your OAuth token is AES-256-GCM encrypted on-device; the PIN is never stored
-- **Captive-portal setup** — connect your phone to the device's WiFi AP and configure everything in a browser
-- **Battery & signal** shown on the dashboard
-- **Button controls** — brightness, screen flip, force refresh, factory reset
+### ⚡ Flash it from your browser
 
-## 🖥️ Supported hardware
+**[oauramos.github.io/claude-usage-stick](https://oauramos.github.io/claude-usage-stick/)** — pick your board, plug it in over USB-C, hit Flash. Nothing to install; Chrome or Edge on desktop.
 
-Each board has its own spec page with pinouts, controls, and quirks — click the name.
-
-| Board | MCU | Display | Firmware | PlatformIO env | Buy |
-| ----- | --- | ------- | -------- | -------------- | --- |
-| [M5StickC Plus](docs/m5stick-cplus.md) | ESP32-PICO | 1.14" 240×135 LCD | 🥭 **Mango (v2)** · tier S | `m5stick-cplus` | [AliExpress](https://s.click.aliexpress.com/e/_c3w3hHWl) |
-| [M5StickC Plus2](docs/m5stick-cplus2.md) | ESP32-PICO-V3-02 | 1.14" 240×135 LCD | Clarity (v1) | `m5stick-cplus2` | [AliExpress](https://s.click.aliexpress.com/e/_c3jkKlNj) |
-| [LilyGo T-Display S3](docs/tdisplay-s3.md) | ESP32-S3 | 1.9" 320×170 LCD | 🥭 **Mango (v2.1.1)** · tier L | `tdisplay-s3` | [AliExpress](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
-| [LilyGo T8 ESP32-S2](docs/t8-s2.md) | ESP32-S2 | 1.14" 135×240 LCD | Clarity (v1) | `t8-s2` | [AliExpress](https://s.click.aliexpress.com/e/_c2w1HnpJ) |
-| [Elecrow CrowPanel Advance 3.5"](docs/crowpanel-adv-35.md) | ESP32-S3 | 3.5" 480×320 IPS touch | Clarity (v1) | `crowpanel-adv-35` | [AliExpress](https://s.click.aliexpress.com/e/_c4lDErmN) |
-| [LilyGo T-Display S3 AMOLED 1.91"](docs/tdisplay-s3-amoled.md) | ESP32-S3 | 1.91" 240×536 AMOLED | Clarity (v1) | `tdisplay-s3-amoled` | [AliExpress](https://s.click.aliexpress.com/e/_c3XNB9Hx) |
-| [TTGO T-Display ESP32](docs/tdisplay-esp32.md) | ESP32 | 1.14" 135×240 LCD | Clarity (v1) | `tdisplay-esp32` | [AliExpress](https://s.click.aliexpress.com/e/_c32HlGQ1) |
-| [ESP32-C3-OLED](docs/esp32c3-oled.md) | ESP32-C3 | 0.42" 72×40 OLED | Clarity (v1) | `esp32c3-oled` | [AliExpress](https://s.click.aliexpress.com/e/_c3JMxywv) |
-| M5Stack StickS3 | — | — | 🚧 in progress | — | [AliExpress](https://s.click.aliexpress.com/e/_c3ZsWHBB) |
-
-Plus any USB-C cable for flashing and power.
-
-## 🎨 The UI
-
-Firmware releases carry names. Each board's current version is listed in the table above.
-
-### Versions
-
-| Version | Name | Highlights |
-| ------- | ---- | ---------- |
-| v1 | **Clarity** | The original dashboard — usage bars, reset countdowns, PIN unlock, captive-portal setup |
-| v2 | 🥭 **Mango** | Everything in Clarity, plus model-status mascots, header icons, inline countdowns, and screen flip — see below |
-
-### Display tiers
-
-The Mango dashboard keeps the same header and usage bars on every board, and adapts only its bottom **MODELS** section to the screen size. Each tier has a reference board; the layout scales to fit.
-
-| Tier | Class | Resolution | Reference board | MODELS section | Status |
-| ---- | ----- | ---------- | --------------- | -------------- | ------ |
-| **XS** | tiny OLED | ≤ 128×64 | ESP32-C3-OLED | — | ⏳ Pending |
-| **S** | small LCD | ~240×135 | **M5StickC Plus** | One overall-health Clawd + a 2×2 `NAME UP/DOWN` text grid | ✅ |
-| **L** | large LCD | ~320×170 | **LilyGo T-Display S3** | A row of four labelled Clawds (one per model), each blinking when healthy | ✅ |
-| **XL** | big / touch | ≥ 480×320 | CrowPanel 3.5", S3 AMOLED | — | ⏳ Pending |
-
-> Boards still on **Clarity (v1)** keep the original minimal dashboard until they're migrated to their tier.
-
-### What Mango adds
-
-- **Model status mascots** — Haiku / Sonnet / Opus / Fable health from the Claude status page; a downed model turns gray with X eyes, healthy ones blink
-- **Header icons** — battery level and WiFi signal strength as icons in the header bar
-- **Reset countdowns by tier** — tier S shows each reset time inline on its bar row; tier L (v2.1.1) gives the countdowns their own large-type row below the bars
-- **Dashboard-styled PIN screen** — the unlock screen matches the dashboard look
-- **Screen flip & brightness** — Button A flips the screen 180°, Button B cycles brightness; refresh happens automatically, or press **A+B** together to force one
-
-## 🚀 Quick start
-
-### Prerequisites
-
-- A supported board connected via USB-C
-- A Claude Code OAuth token (run `claude setup-token` in your terminal)
-- [PlatformIO CLI](https://platformio.org/install/cli) — only if you flash from source; the web flasher needs nothing installed
-
-### 1. Flash the firmware
-
-**⚡ From your browser (recommended):** open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge on desktop, pick your board, plug it in over USB-C, and hit Flash. Firmware images are built and published automatically from `main`.
-
-**From source:** pick your board's env from the [hardware table](#%EF%B8%8F-supported-hardware), then:
+### Or build from source
 
 ```bash
 git clone https://github.com/oauramos/claude-usage-stick.git
@@ -105,82 +35,31 @@ pio run -e <env> -t upload      # firmware
 pio run -e <env> -t uploadfs    # web setup UI (SPIFFS)
 ```
 
-> **Apple Silicon note:** If `uploadfs` fails with "Bad CPU type", install Rosetta (`softwareupdate --install-rosetta`) or use the included Python fallback:
-> ```bash
-> python3 upload_data.py
-> ```
+Needs the [PlatformIO CLI](https://platformio.org/install/cli). Board envs are listed in [Supported boards](https://github.com/oauramos/claude-usage-stick/wiki/Supported-Boards).
 
-### 2. Configure the device
+Either way, the device then opens its own WiFi network so you can configure it from your phone — see [Setup and daily use](https://github.com/oauramos/claude-usage-stick/wiki/Setup-and-Daily-Use).
 
-1. On first boot (or after factory reset), the device creates a WiFi access point named `ClaudeMonitor-XXXX`
-2. Connect your phone or laptop to that network — the password is shown on the device screen
-3. Open `http://192.168.4.1` in a browser
-4. Fill in your WiFi credentials, OAuth token, and a 4-digit encryption PIN
-5. Hit **Save & Reboot** — the device encrypts the token, stores it, and connects to your WiFi
+## Documentation
 
-### 3. Daily use
+Everything lives in the **[wiki](https://github.com/oauramos/claude-usage-stick/wiki)**:
 
-On each boot, enter your PIN using the device buttons: **Button A** cycles the current digit (0–9), **Button B** confirms and moves to the next. Once unlocked, the dashboard appears and auto-refreshes.
+| | |
+| --- | --- |
+| [Features](https://github.com/oauramos/claude-usage-stick/wiki/Features) | What the device shows |
+| [The UI](https://github.com/oauramos/claude-usage-stick/wiki/The-UI) | Firmware versions and display tiers |
+| [Supported boards](https://github.com/oauramos/claude-usage-stick/wiki/Supported-Boards) | The lineup, with a guide for each board |
+| [Flashing](https://github.com/oauramos/claude-usage-stick/wiki/Flashing) | Web flasher and building from source |
+| [Setup and daily use](https://github.com/oauramos/claude-usage-stick/wiki/Setup-and-Daily-Use) | Captive-portal setup, PIN, controls |
+| [How it works](https://github.com/oauramos/claude-usage-stick/wiki/How-It-Works) | The API request and the headers it reads |
+| [Security](https://github.com/oauramos/claude-usage-stick/wiki/Security) | How your OAuth token is encrypted on-device |
+| [Troubleshooting](https://github.com/oauramos/claude-usage-stick/wiki/Troubleshooting) | When something doesn't work |
 
-| Button | Clarity (v1) | 🥭 Mango (v2) |
-| ------ | ------------ | ------------- |
-| A | Cycle brightness | Flip screen 180° |
-| B | Force refresh | Cycle brightness |
-| A+B | — | Force refresh |
-| A+B held on boot | Factory reset | Factory reset |
+Wiki pages are written in [`wiki/`](wiki/) and published automatically, so docs get reviewed in PRs like any other change.
 
-> Single-button and touch boards (T8-S2, CrowPanel, AMOLED, ESP32-C3-OLED) map these differently — see your [board's page](#%EF%B8%8F-supported-hardware).
+## Contributing
 
-## ⚙️ How it works
+PRs welcome — especially new board support and photos of real builds. See [Project structure](https://github.com/oauramos/claude-usage-stick/wiki/Project-Structure) for the repo layout and what adding a board involves.
 
-1. The device sends a minimal API request (`max_tokens: 1`) to the Anthropic Messages endpoint using your OAuth token
-2. It reads the `anthropic-ratelimit-unified-5h-utilization` and `anthropic-ratelimit-unified-7d-utilization` response headers
-3. The dashboard updates on a configurable interval (30s–5min)
-
-The token never leaves the device. It is encrypted with AES-256-GCM using a key derived from your PIN (PBKDF via iterated SHA-256, 10 000 rounds).
-
-## 🔐 Security
-
-- The OAuth token is encrypted with AES-256-GCM before being written to NVS flash
-- The encryption key is derived from your PIN + device MAC salt through 10 000 rounds of SHA-256
-- The PIN is **never stored** — wrong PIN = failed decryption (GCM tag mismatch)
-- After 10 failed PIN attempts, all credentials are wiped and the device resets to setup mode
-- Lockout delay doubles after each failure (60s → 120s → 240s → ...)
-
-## 🗂️ Project structure
-
-```
-assets/           — images (hero, gallery, wiring photos)
-docs/             — per-board hardware specs, flashing & controls
-src/
-  main.cpp        — boot flow, WiFi, PIN entry, main loop
-  hal.cpp/h       — hardware abstraction (display, buttons, battery, backlight)
-  api.cpp/h       — HTTPS request to Anthropic, header parsing
-  crypto.cpp/h    — AES-256-GCM encrypt/decrypt with PIN-derived key
-  provision.cpp/h — captive portal WiFi AP + web server
-  ui.cpp/h        — all LCD drawing (boot, PIN, dashboard, errors)
-  config.h        — tunables (poll interval, timeouts, PIN attempts)
-data/
-  setup.html      — web UI served during provisioning
-server/
-  usage_proxy.py  — optional local caching proxy (reads token from macOS Keychain)
-platformio.ini    — one build env per board
-```
-
-## 📸 Gallery
-
-Real builds in the wild. Got a Claude Usage Stick on your desk? PRs with photos are welcome!
-
-<p align="center">
-  <img src="assets/boot.jpg" width="260" alt="Boot screen">
-  <img src="assets/pin.jpg" width="260" alt="PIN unlock">
-  <img src="assets/dashboard.jpg" width="260" alt="Dashboard">
-</p>
-
-<p align="center">
-  <img src="assets/esp32-c3-oled.jpg" width="400" alt="ESP32-C3-OLED running Claude Usage Stick">
-</p>
-
-## 📄 License
+## License
 
 [MIT](LICENSE)

--- a/web/index.html
+++ b/web/index.html
@@ -831,7 +831,7 @@
   <div class="wrap foot-in">
     <span>MIT © oauramos</span>
     <a href="https://github.com/oauramos/claude-usage-stick" target="_blank" rel="noopener">GitHub</a>
-    <a href="https://github.com/oauramos/claude-usage-stick/tree/main/docs" target="_blank" rel="noopener">Board docs</a>
+    <a href="https://github.com/oauramos/claude-usage-stick/wiki/Supported-Boards" target="_blank" rel="noopener">Board docs</a>
     <span class="spacer"></span>
     <span>flashing powered by ESP Web Tools</span>
   </div>

--- a/web/src/template.html
+++ b/web/src/template.html
@@ -663,7 +663,7 @@
   <div class="wrap foot-in">
     <span>MIT © oauramos</span>
     <a href="https://github.com/oauramos/claude-usage-stick" target="_blank" rel="noopener">GitHub</a>
-    <a href="https://github.com/oauramos/claude-usage-stick/tree/main/docs" target="_blank" rel="noopener">Board docs</a>
+    <a href="https://github.com/oauramos/claude-usage-stick/wiki/Supported-Boards" target="_blank" rel="noopener">Board docs</a>
     <span class="spacer"></span>
     <span>flashing powered by ESP Web Tools</span>
   </div>

--- a/wiki/CrowPanel-Advance-35.md
+++ b/wiki/CrowPanel-Advance-35.md
@@ -1,6 +1,6 @@
 # Elecrow CrowPanel Advance 3.5" HMI
 
-Part of [Claude Usage Stick](../README.md). The biggest screen in the lineup — a 3.5" 480×320 IPS HMI panel with capacitive touch and no physical buttons. Pin mapping comes from Elecrow's official LovyanGFX driver and is verified on hardware.
+Part of [Claude Usage Stick](Home). The biggest screen in the lineup — a 3.5" 480×320 IPS HMI panel with capacitive touch and no physical buttons. Pin mapping comes from Elecrow's official LovyanGFX driver and is verified on hardware.
 
 ## Specs
 
@@ -17,6 +17,10 @@ Part of [Claude Usage Stick](../README.md). The biggest screen in the lineup —
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c4lDErmN) |
 
 ## Flash
+
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+
+From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 
 ```bash
 pio run -e crowpanel-adv-35 -t upload     # firmware
@@ -38,3 +42,7 @@ There are no physical user buttons, so the two-button UX maps to halves of the t
 - **No battery readout** — battery percentage isn't shown on the dashboard.
 - The dashboard renders into a PSRAM sprite and is pushed in one transfer, so refreshes don't flicker on this slow SPI panel; the PIN/setup screens draw straight to the panel so touch input stays responsive.
 - During setup, the WiFi AP password is shown on the device screen.
+
+---
+
+**CrowPanel Advance 35** · env `crowpanel-adv-35` · [All boards](Supported-Boards) · [Flashing](Flashing) · [Setup and daily use](Setup-and-Daily-Use) · [Troubleshooting](Troubleshooting)

--- a/wiki/ESP32-C3-OLED.md
+++ b/wiki/ESP32-C3-OLED.md
@@ -1,9 +1,9 @@
 # ESP32-C3-OLED
 
-Part of [Claude Usage Stick](../README.md). The smallest and cheapest way to run the firmware — a breadboard-friendly ESP32-C3 module with a 0.42" OLED. It has no built-in buttons, so you bring your own (two tactile buttons or capacitive touch pads).
+Part of [Claude Usage Stick](Home). The smallest and cheapest way to run the firmware — a breadboard-friendly ESP32-C3 module with a 0.42" OLED. It has no built-in buttons, so you bring your own (two tactile buttons or capacitive touch pads).
 
 <p align="center">
-  <img src="../assets/esp32-c3-oled.jpg" width="400" alt="ESP32-C3-OLED running Claude Usage Stick">
+  <img src="https://raw.githubusercontent.com/oauramos/claude-usage-stick/main/assets/esp32-c3-oled.jpg" width="400" alt="ESP32-C3-OLED running Claude Usage Stick">
 </p>
 
 ## Specs
@@ -19,6 +19,10 @@ Part of [Claude Usage Stick](../README.md). The smallest and cheapest way to run
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c3JMxywv) |
 
 ## Flash
+
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+
+From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 
 ```bash
 pio run -e esp32c3-oled -t upload     # firmware
@@ -53,7 +57,7 @@ Wire each button between the GPIO pin and 3.3 V. When the button is open the int
 Any module that outputs a logic-HIGH signal when touched works as a drop-in replacement (e.g. TTP223-based pads). Wire the sensor's output to the GPIO pin and its power pins to 3.3 V and GND. The signal polarity and pull-down behaviour are identical to Option A.
 
 <p align="center">
-  <img src="../assets/esp32-c3-oled-touch-buttons.jpg" width="500" alt="ESP32-C3-OLED wired with capacitive touch sensors on GPIO 3 and GPIO 7">
+  <img src="https://raw.githubusercontent.com/oauramos/claude-usage-stick/main/assets/esp32-c3-oled-touch-buttons.jpg" width="500" alt="ESP32-C3-OLED wired with capacitive touch sensors on GPIO 3 and GPIO 7">
 </p>
 
 ## Controls
@@ -68,3 +72,7 @@ Any module that outputs a logic-HIGH signal when touched works as a drop-in repl
 
 - During setup, a simple 8-digit WiFi AP password is shown on the OLED (`Pass:` line) — the tiny screen can't fit the full random password used by LCD boards.
 - Brightness control is a simple on/off toggle (the 72×40 OLED has no meaningful brightness steps).
+
+---
+
+**ESP32 C3 OLED** · env `esp32c3-oled` · [All boards](Supported-Boards) · [Flashing](Flashing) · [Setup and daily use](Setup-and-Daily-Use) · [Troubleshooting](Troubleshooting)

--- a/wiki/Features.md
+++ b/wiki/Features.md
@@ -1,0 +1,31 @@
+# Features
+
+What the device shows once it's on your desk. For how the layout changes per screen size, see [The UI](The-UI).
+
+## Live usage bars
+
+Two bars, one per rate-limit window: the **5-hour** and the **7-day**. They refresh on a configurable interval (30 s to 5 min) straight from the Anthropic API — see [How it works](How-It-Works).
+
+## Reset countdowns
+
+Each window shows how long until capacity frees up, so you know whether to keep going or take a break. On [tier L](The-UI#display-tiers) the countdowns get their own large-type row; on tier S they sit inline on each bar.
+
+## Model status mascots
+
+*Mango (v2) only.* Haiku, Sonnet, Opus and Fable health, pulled from [status.claude.com](https://status.claude.com) and drawn as Clawd mascots. A healthy model blinks; a downed one turns gray with X eyes. Small screens show the same information as a `NAME UP/DOWN` text grid instead of mascots.
+
+## PIN-protected token
+
+Your OAuth token is AES-256-GCM encrypted on the device's flash, with the key derived from a 4-digit PIN you choose. The PIN itself is never stored. Full details in [Security](Security).
+
+## Captive-portal setup
+
+No hardcoded credentials and no serial console. On first boot the device opens its own WiFi access point; you join it from your phone and fill in a form. Walkthrough in [Setup and daily use](Setup-and-Daily-Use).
+
+## Battery and signal
+
+Battery level and WiFi signal strength appear as icons in the dashboard header — on boards that have a battery-sense ADC. A few boards can't read battery voltage; their guides say so.
+
+## Button controls
+
+Brightness, screen flip, force refresh, and factory reset, all from the board's buttons. The exact mapping differs per board (some have two buttons, some one, some only a touch screen) — see [Setup and daily use](Setup-and-Daily-Use#controls) or your [board's guide](Supported-Boards).

--- a/wiki/Flashing.md
+++ b/wiki/Flashing.md
@@ -1,0 +1,54 @@
+# Flashing
+
+Two ways to get the firmware onto a board. The web flasher needs nothing installed; building from source is for development or for boards whose CI build isn't published yet.
+
+## From your browser (recommended)
+
+Open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)**, pick your board, plug it in over USB-C, and click Flash.
+
+Requirements:
+
+- **Chrome, Edge, or Opera on desktop.** The flasher uses the Web Serial API, which Firefox, Safari, and every browser on iOS/Android do not implement.
+- **A USB-C data cable.** Charge-only cables power the board but carry no data.
+- If the board isn't detected, hold **BOOT** while plugging it in to force download mode.
+
+Firmware images are built from `main` by CI and published alongside the page, so the flasher always serves the current build. A board whose build hasn't landed is grayed out and labelled *build pending*.
+
+## From source
+
+You need the [PlatformIO CLI](https://platformio.org/install/cli). Pick your board's env from [Supported boards](Supported-Boards):
+
+```bash
+git clone https://github.com/oauramos/claude-usage-stick.git
+cd claude-usage-stick
+
+pio run -e <env> -t upload      # firmware
+pio run -e <env> -t uploadfs    # web setup UI (SPIFFS)
+```
+
+### Apple Silicon note
+
+If `uploadfs` fails with *"Bad CPU type"*, the bundled mkspiffs binary is x86-only. Either install Rosetta:
+
+```bash
+softwareupdate --install-rosetta
+```
+
+or use the Python fallback included in the repo:
+
+```bash
+python3 upload_data.py
+```
+
+### Known build issues
+
+Two envs currently fail to build in some environments for reasons unrelated to the firmware itself:
+
+- **`m5stick-cplus2`** — a dependency pin conflict
+- **`tdisplay-s3-amoled`** — an `intelhex` failure in the LilyGo AMOLED toolchain
+
+These are environmental, not regressions. When they fail in CI, the affected board simply shows as *build pending* on the web flasher; every other board still deploys.
+
+## After flashing
+
+The device reboots into setup mode and opens its own WiFi access point — continue with [Setup and daily use](Setup-and-Daily-Use).

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -1,0 +1,41 @@
+# Claude Usage Stick
+
+**Your [Claude Code](https://docs.anthropic.com/en/docs/claude-code) rate limits, glanceable on a tiny ESP32 stick.**
+
+A standalone desk gadget that polls the Anthropic API and shows your rate-limit usage in real time — no computer, no app, no cloud. Flash it, connect it to WiFi from your phone, and it just sits there telling you how much runway you have left.
+
+<img src="https://github.com/user-attachments/assets/c51c5a9e-5a3e-4c3e-97a8-d5a4c5a44263" width="640" alt="Claude Usage Stick — PIN unlock screen and usage dashboard on a LilyGo T-Display S3">
+
+## Start here
+
+| | |
+| --- | --- |
+| **New here?** | [Features](Features) — what the device actually shows |
+| **Ready to build one?** | [Supported boards](Supported-Boards), then [Flashing](Flashing) |
+| **Just flashed it?** | [Setup and daily use](Setup-and-Daily-Use) |
+| **Something's wrong?** | [Troubleshooting](Troubleshooting) |
+
+The fastest path to a working device: pick a board from the [supported list](Supported-Boards), open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, and plug the board in over USB-C. No toolchain, no drivers, no clone.
+
+## All pages
+
+**Using the device**
+- [Features](Features) — usage bars, reset countdowns, model mascots, PIN lock
+- [The UI](The-UI) — firmware versions (Clarity, Mango) and how the layout adapts per screen size
+- [Setup and daily use](Setup-and-Daily-Use) — captive-portal setup, PIN entry, button controls
+- [Troubleshooting](Troubleshooting) — flashing, WiFi, token, and display problems
+
+**Hardware**
+- [Supported boards](Supported-Boards) — the full lineup, with a guide for each
+- Board guides: [M5StickC Plus](M5StickC-Plus) · [M5StickC Plus2](M5StickC-Plus2) · [LilyGo T-Display S3](LilyGo-T-Display-S3) · [LilyGo T8 ESP32-S2](LilyGo-T8-ESP32-S2) · [CrowPanel Advance 3.5"](CrowPanel-Advance-35) · [T-Display S3 AMOLED](LilyGo-T-Display-S3-AMOLED) · [TTGO T-Display](TTGO-T-Display-ESP32) · [ESP32-C3-OLED](ESP32-C3-OLED)
+
+**Under the hood**
+- [Flashing](Flashing) — the web flasher and building from source
+- [How it works](How-It-Works) — the API request and the headers it reads
+- [Security](Security) — how your OAuth token is encrypted on-device
+- [Project structure](Project-Structure) — repo layout and how to add a board
+
+## Project links
+
+- [Repository](https://github.com/oauramos/claude-usage-stick) · [Web flasher](https://oauramos.github.io/claude-usage-stick/) · [Issues](https://github.com/oauramos/claude-usage-stick/issues)
+- License: [MIT](https://github.com/oauramos/claude-usage-stick/blob/main/LICENSE)

--- a/wiki/How-It-Works.md
+++ b/wiki/How-It-Works.md
@@ -1,0 +1,28 @@
+# How it works
+
+The whole device is a loop: ask the Anthropic API a trivial question, read the rate-limit headers off the answer, draw them.
+
+## The polling loop
+
+1. The device sends a minimal request to the Anthropic Messages endpoint using your OAuth token — `max_tokens: 1`, so it costs essentially nothing.
+2. It ignores the response body and reads two response headers:
+   - `anthropic-ratelimit-unified-5h-utilization`
+   - `anthropic-ratelimit-unified-7d-utilization`
+3. It draws those percentages as bars, along with the reset countdowns.
+4. It sleeps until the next poll — the interval is configurable from 30 s to 5 min.
+
+On [Mango](The-UI) firmware the device also fetches model health from [status.claude.com](https://status.claude.com) and draws the Haiku / Sonnet / Opus / Fable mascots.
+
+## Where your token goes
+
+Nowhere except Anthropic. There is no backend, no telemetry, and no cloud service in the middle — the device talks straight to `api.anthropic.com` over HTTPS. The token itself is stored encrypted on the device's own flash; see [Security](Security).
+
+## Rate-limit headers and your plan
+
+The unified 5h/7d headers are what Claude Code subscriptions (Pro and Max) return. **Enterprise and API-billed accounts do not emit them** — the request succeeds with HTTP 200, but the headers simply aren't there, and the device can't show usage.
+
+If your device reports `no_usage_h_200`, that's what happened: the token is valid, but the plan behind it doesn't publish unified usage. You need a Pro or Max token. See [Troubleshooting](Troubleshooting#the-device-shows-no_usage_h_200).
+
+## Optional local proxy
+
+The repo ships `server/usage_proxy.py`, a small caching proxy that reads the token from the macOS Keychain. It's useful if you'd rather not put a token on the device at all, or if you want several devices sharing one upstream poll. It is entirely optional — the device works standalone without it.

--- a/wiki/LilyGo-T-Display-S3-AMOLED.md
+++ b/wiki/LilyGo-T-Display-S3-AMOLED.md
@@ -1,6 +1,6 @@
 # LilyGo T-Display S3 AMOLED (1.91")
 
-Part of [Claude Usage Stick](../README.md). The AMOLED variant of the T-Display S3 — a long, narrow 240×536 RM67162 panel. One build covers every 1.91" revision: the panel variant (H712 / H713 / H705 / H681 / H717) is auto-detected at runtime by the LilyGo_AMOLED library, touch and non-touch, V1.0/V2.0/Black Shell alike.
+Part of [Claude Usage Stick](Home). The AMOLED variant of the T-Display S3 — a long, narrow 240×536 RM67162 panel. One build covers every 1.91" revision: the panel variant (H712 / H713 / H705 / H681 / H717) is auto-detected at runtime by the LilyGo_AMOLED library, touch and non-touch, V1.0/V2.0/Black Shell alike.
 
 ## Specs
 
@@ -17,12 +17,16 @@ Part of [Claude Usage Stick](../README.md). The AMOLED variant of the T-Display 
 
 ## Flash
 
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+
+From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
+
 ```bash
 pio run -e tdisplay-s3-amoled -t upload     # firmware
 pio run -e tdisplay-s3-amoled -t uploadfs   # web setup UI (SPIFFS)
 ```
 
-> This env is for the **1.91" AMOLED variant**. For the regular LCD version, use [`tdisplay-s3`](tdisplay-s3.md).
+> This env is for the **1.91" AMOLED variant**. For the regular LCD version, use [`tdisplay-s3`](LilyGo-T-Display-S3).
 
 ## Controls
 
@@ -35,3 +39,7 @@ pio run -e tdisplay-s3-amoled -t uploadfs   # web setup UI (SPIFFS)
 
 - **Button B requires touch** — on non-touch variants (H712 / H713) there is no Button B input, so the touch-equipped revisions are the better pick.
 - During setup, the WiFi AP password is shown on the device screen.
+
+---
+
+**LilyGo T Display S3 AMOLED** · env `tdisplay-s3-amoled` · [All boards](Supported-Boards) · [Flashing](Flashing) · [Setup and daily use](Setup-and-Daily-Use) · [Troubleshooting](Troubleshooting)

--- a/wiki/LilyGo-T-Display-S3.md
+++ b/wiki/LilyGo-T-Display-S3.md
@@ -1,6 +1,6 @@
 # LilyGo T-Display S3
 
-Part of [Claude Usage Stick](../README.md). The biggest small-format screen in the lineup — a 1.9" LCD driven over a fast 8-bit parallel bus, with two front buttons and a battery connector.
+Part of [Claude Usage Stick](Home). The biggest small-format screen in the lineup — a 1.9" LCD driven over a fast 8-bit parallel bus, with two front buttons and a battery connector.
 
 ## Specs
 
@@ -16,12 +16,16 @@ Part of [Claude Usage Stick](../README.md). The biggest small-format screen in t
 
 ## Flash
 
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+
+From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
+
 ```bash
 pio run -e tdisplay-s3 -t upload     # firmware
 pio run -e tdisplay-s3 -t uploadfs   # web setup UI (SPIFFS)
 ```
 
-> This env is for the **regular LCD variant**. For the 1.91" AMOLED version, use [`tdisplay-s3-amoled`](tdisplay-s3-amoled.md).
+> This env is for the **regular LCD variant**. For the 1.91" AMOLED version, use [`tdisplay-s3-amoled`](LilyGo-T-Display-S3-AMOLED).
 
 ## Controls
 
@@ -36,5 +40,9 @@ Refresh happens automatically on the poll interval; press **A+B** together to fo
 
 ## Notes
 
-- As the **tier L** reference board, the dashboard shows the 5H/7D reset countdowns in large type on their own row below the bars, and the MODELS section shows a row of four labelled Clawd mascots (Haiku / Sonnet / Opus / Fable), each blinking while healthy — see [Display tiers](../README.md#display-tiers).
+- As the **tier L** reference board, the dashboard shows the 5H/7D reset countdowns in large type on their own row below the bars, and the MODELS section shows a row of four labelled Clawd mascots (Haiku / Sonnet / Opus / Fable), each blinking while healthy — see [Display tiers](The-UI#display-tiers).
 - During setup, the WiFi AP password is shown on the device screen.
+
+---
+
+**LilyGo T Display S3** · env `tdisplay-s3` · [All boards](Supported-Boards) · [Flashing](Flashing) · [Setup and daily use](Setup-and-Daily-Use) · [Troubleshooting](Troubleshooting)

--- a/wiki/LilyGo-T8-ESP32-S2.md
+++ b/wiki/LilyGo-T8-ESP32-S2.md
@@ -1,6 +1,6 @@
 # LilyGo T8 ESP32-S2
 
-Part of [Claude Usage Stick](../README.md). A bare-bones ESP32-S2 board with the same 1.14" ST7789 panel as the TTGO T-Display, wired over the broken-out FSPI pins. Verified on hardware — display, WiFi provisioning, the encrypted dashboard, and button input all work.
+Part of [Claude Usage Stick](Home). A bare-bones ESP32-S2 board with the same 1.14" ST7789 panel as the TTGO T-Display, wired over the broken-out FSPI pins. Verified on hardware — display, WiFi provisioning, the encrypted dashboard, and button input all work.
 
 ## Specs
 
@@ -16,6 +16,10 @@ Part of [Claude Usage Stick](../README.md). A bare-bones ESP32-S2 board with the
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c2w1HnpJ) |
 
 ## Flash
+
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+
+From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 
 ```bash
 pio run -e t8-s2 -t upload     # firmware
@@ -36,3 +40,7 @@ The board exposes only the onboard **BOOT** button (GPIO 0), so the two-button U
 - **No on-boot factory reset** — GPIO 0 is a strapping pin (holding it during reset enters download mode), so the "hold A+B on boot" combo is unavailable. Re-flash to wipe NVS.
 - **No battery readout** — there's no confirmed battery-sense ADC, so battery percentage isn't shown on the dashboard.
 - During setup, the WiFi AP password is shown on the device screen.
+
+---
+
+**LilyGo T8 ESP32 S2** · env `t8-s2` · [All boards](Supported-Boards) · [Flashing](Flashing) · [Setup and daily use](Setup-and-Daily-Use) · [Troubleshooting](Troubleshooting)

--- a/wiki/M5StickC-Plus.md
+++ b/wiki/M5StickC-Plus.md
@@ -1,6 +1,6 @@
 # M5StickC Plus
 
-Part of [Claude Usage Stick](../README.md). The original board this project was built for — a finger-sized ESP32 stick with a built-in display, battery, and two buttons. Zero soldering required.
+Part of [Claude Usage Stick](Home). The original board this project was built for — a finger-sized ESP32 stick with a built-in display, battery, and two buttons. Zero soldering required.
 
 ## Specs
 
@@ -15,6 +15,10 @@ Part of [Claude Usage Stick](../README.md). The original board this project was 
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c3w3hHWl) |
 
 ## Flash
+
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+
+From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 
 ```bash
 pio run -e m5stick-cplus -t upload     # firmware
@@ -33,5 +37,9 @@ Refresh happens automatically on the poll interval — Mango has no manual-refre
 
 ## Notes
 
-- As the **tier S** reference board, the dashboard's MODELS section shows one overall-health Clawd mascot plus a 2×2 `NAME UP/DOWN` text grid — see [Display tiers](../README.md#display-tiers).
+- As the **tier S** reference board, the dashboard's MODELS section shows one overall-health Clawd mascot plus a 2×2 `NAME UP/DOWN` text grid — see [Display tiers](The-UI#display-tiers).
 - During setup, the WiFi AP password is shown on the device screen.
+
+---
+
+**M5StickC Plus** · env `m5stick-cplus` · [All boards](Supported-Boards) · [Flashing](Flashing) · [Setup and daily use](Setup-and-Daily-Use) · [Troubleshooting](Troubleshooting)

--- a/wiki/M5StickC-Plus2.md
+++ b/wiki/M5StickC-Plus2.md
@@ -1,6 +1,6 @@
 # M5StickC Plus2
 
-Part of [Claude Usage Stick](../README.md). The successor to the M5StickC Plus — same form factor, newer ESP32-PICO-V3-02 module, bigger battery.
+Part of [Claude Usage Stick](Home). The successor to the M5StickC Plus — same form factor, newer ESP32-PICO-V3-02 module, bigger battery.
 
 ## Specs
 
@@ -15,6 +15,10 @@ Part of [Claude Usage Stick](../README.md). The successor to the M5StickC Plus �
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c3jkKlNj) |
 
 ## Flash
+
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+
+From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 
 ```bash
 pio run -e m5stick-cplus2 -t upload     # firmware
@@ -33,3 +37,7 @@ pio run -e m5stick-cplus2 -t uploadfs   # web setup UI (SPIFFS)
 
 - Runs the original **Clarity** dashboard until it's migrated to the Mango tier S layout.
 - During setup, the WiFi AP password is shown on the device screen.
+
+---
+
+**M5StickC Plus2** · env `m5stick-cplus2` · [All boards](Supported-Boards) · [Flashing](Flashing) · [Setup and daily use](Setup-and-Daily-Use) · [Troubleshooting](Troubleshooting)

--- a/wiki/Project-Structure.md
+++ b/wiki/Project-Structure.md
@@ -1,0 +1,53 @@
+# Project structure
+
+```
+assets/           — images (hero, gallery, wiring photos)
+wiki/             — the source of these wiki pages; CI publishes it to the wiki
+src/
+  main.cpp        — boot flow, WiFi, PIN entry, main loop
+  hal.cpp/h       — hardware abstraction (display, buttons, battery, backlight)
+  api.cpp/h       — HTTPS request to Anthropic, header parsing
+  crypto.cpp/h    — AES-256-GCM encrypt/decrypt with PIN-derived key
+  provision.cpp/h — captive portal WiFi AP + web server
+  ui.cpp/h        — all LCD drawing (boot, PIN, dashboard, errors)
+  config.h        — tunables (poll interval, timeouts, PIN attempts)
+data/
+  setup.html      — web UI served during provisioning
+server/
+  usage_proxy.py  — optional local caching proxy (reads token from macOS Keychain)
+web/              — the browser-based flasher published to GitHub Pages
+platformio.ini    — one build env per board
+```
+
+## Editing these docs
+
+The wiki is **generated from the repo**. Pages live in `wiki/` on `main`, and a GitHub Action pushes them to the wiki whenever they change — so documentation gets reviewed in pull requests like any other change.
+
+Edit the file in `wiki/`, open a PR, and the wiki updates on merge. Editing a page directly in the wiki UI works too, but the next sync will overwrite it.
+
+## Editing the web flasher
+
+`web/index.html` and `web/manifests/*.json` are generated. Edit `web/src/template.html` and run:
+
+```bash
+python3 web/src/build.py
+```
+
+The board list, firmware versions, and the CSS 3D board models are data inside `web/src/build.py`. Commit the regenerated files with your source change. More detail in [`web/README.md`](https://github.com/oauramos/claude-usage-stick/blob/main/web/README.md).
+
+## Adding a board
+
+Roughly what's involved:
+
+1. **`platformio.ini`** — a new env with the board's platform, display driver flags, and pin mapping.
+2. **`src/hal.cpp`** — a branch for the board's display init, buttons, battery ADC, and backlight, behind a `BOARD_*` define.
+3. **`src/ui.cpp`** — usually nothing, if the board fits an existing [display tier](The-UI#display-tiers). A new resolution class means a new tier.
+4. **`wiki/`** — a board guide page, plus a row in [Supported boards](Supported-Boards).
+5. **`web/src/build.py`** — an entry in `BOARDS` and a 3D model in `BOARDS3D`, so the board appears in the flasher.
+6. **`.github/workflows/pages.yml`** — add the env to the build matrix.
+
+Pin mappings should be verified on real hardware before being merged — several boards in this repo have pin maps that only match after checking against the vendor's own driver.
+
+## Contributing
+
+PRs are welcome, especially board support and photos of real builds. Open an [issue](https://github.com/oauramos/claude-usage-stick/issues) first if you're planning something large.

--- a/wiki/Security.md
+++ b/wiki/Security.md
@@ -1,0 +1,32 @@
+# Security
+
+Your OAuth token grants access to your Claude account, and it lives on a small device on your desk. Here's exactly how it's protected.
+
+## Token storage
+
+- The token is encrypted with **AES-256-GCM** before it's written to NVS flash.
+- The encryption key is derived from **your PIN plus the device's MAC address as salt**, through 10 000 rounds of SHA-256.
+- The **PIN is never stored**, anywhere, in any form. A wrong PIN produces a wrong key, and decryption fails on the GCM authentication tag — the device can tell the PIN was wrong without ever having kept a copy of the right one.
+
+The practical consequence: if you forget the PIN, the token is unrecoverable. Factory reset and set the device up again.
+
+## Brute-force protection
+
+- After **10 consecutive failed PIN attempts**, the device wipes all stored credentials and returns to setup mode.
+- The lockout delay **doubles after each failure**: 60 s, then 120 s, then 240 s, and so on. Ten guesses take a long time.
+
+## What this does and doesn't protect against
+
+**Protected:** someone who picks up your device and tries to read the token off it, or guesses PINs at the screen. Without the PIN, the flash contents are ciphertext.
+
+**Not protected:** someone with physical access, a soldering iron, and the willingness to attack the flash chip directly while you're using the device. This is a desk gadget, not a hardware security module. Treat the token accordingly — it's a Claude Code token, and you can revoke and reissue it at any time with `claude setup-token`.
+
+## Network
+
+The device talks to `api.anthropic.com` over HTTPS and to `status.claude.com` for model health. Nothing else. There's no backend, no telemetry, and no update channel — see [How it works](How-It-Works).
+
+During setup the device runs an open-ish access point (`ClaudeMonitor-XXXX`, password shown on its screen) that serves a plain HTTP form on `192.168.4.1`. That's a brief window on a local AP with a password, and it closes as soon as you hit Save & Reboot — but it does mean you shouldn't do first-time setup somewhere hostile, like a crowded conference.
+
+## Rotating the token
+
+Factory reset the device (hold **A+B** on boot, or re-flash on boards that can't), then run `claude setup-token` again and redo [setup](Setup-and-Daily-Use).

--- a/wiki/Setup-and-Daily-Use.md
+++ b/wiki/Setup-and-Daily-Use.md
@@ -1,0 +1,58 @@
+# Setup and daily use
+
+Everything after [flashing](Flashing): getting the device onto your WiFi, then living with it.
+
+## What you need
+
+- A Claude Code OAuth token. Run this in your terminal and copy the result:
+  ```bash
+  claude setup-token
+  ```
+- Your WiFi network name and password (2.4 GHz — ESP32 boards don't do 5 GHz).
+- A 4-digit PIN you'll remember. It encrypts the token and is **never stored**, so there is no recovery if you forget it.
+
+## First-time setup
+
+On first boot — or after a factory reset — the device starts a captive portal.
+
+1. The device screen shows a WiFi network named `ClaudeMonitor-XXXX` along with its password. Join that network from your phone or laptop.
+2. Open **`http://192.168.4.1`** in a browser. (Most phones pop the page up automatically.)
+3. Fill in the form: WiFi credentials, your OAuth token, and your 4-digit PIN.
+4. Hit **Save & Reboot**.
+
+The device encrypts the token with your PIN, stores it, and connects to your WiFi. See [Security](Security) for what that encryption actually does.
+
+> On the [ESP32-C3-OLED](ESP32-C3-OLED) the screen is too small for the full random password, so it shows a simpler 8-digit one instead.
+
+## Daily use
+
+On every boot you enter your PIN with the board's buttons:
+
+- **Button A** cycles the current digit (0–9)
+- **Button B** confirms it and moves to the next
+
+Once unlocked, the dashboard appears and refreshes on its own.
+
+## Controls
+
+| Button | Clarity (v1) | 🥭 Mango (v2) |
+| ------ | ------------ | ------------- |
+| A | Cycle brightness | Flip screen 180° |
+| B | Force refresh | Cycle brightness |
+| A+B | — | Force refresh |
+| A+B held on boot | Factory reset | Factory reset |
+
+Boards without two buttons map this differently — one button by press duration, or touch zones on the touch panels. Check your [board's guide](Supported-Boards):
+
+- [LilyGo T8 ESP32-S2](LilyGo-T8-ESP32-S2) — short tap = A, long press = B
+- [CrowPanel Advance 3.5"](CrowPanel-Advance-35) — tap left half = A, tap right half = B
+- [T-Display S3 AMOLED](LilyGo-T-Display-S3-AMOLED) — physical button = A, tap the screen = B
+- [ESP32-C3-OLED](ESP32-C3-OLED) — buttons you wire yourself on GPIO 3 and GPIO 7
+
+## Factory reset
+
+Holding **A+B** while the device boots wipes every stored credential and returns it to setup mode. Use this when changing WiFi networks or rotating your token.
+
+Three boards can't do it in hardware — the T8-S2 and CrowPanel have no way to signal two simultaneous inputs, and GPIO 0 is a strapping pin. Re-flash those boards to wipe their storage.
+
+Note that the device also wipes itself after **10 consecutive wrong PIN attempts**, with the lockout delay doubling each time (60 s → 120 s → 240 s …).

--- a/wiki/Supported-Boards.md
+++ b/wiki/Supported-Boards.md
@@ -1,0 +1,44 @@
+# Supported boards
+
+Eight boards run the firmware today. Each has its own guide with pinouts, controls, and quirks — click the name.
+
+| Board | MCU | Display | Firmware | PlatformIO env | Buy |
+| ----- | --- | ------- | -------- | -------------- | --- |
+| [M5StickC Plus](M5StickC-Plus) | ESP32-PICO | 1.14" 240×135 LCD | 🥭 **Mango (v2)** · tier S | `m5stick-cplus` | [AliExpress](https://s.click.aliexpress.com/e/_c3w3hHWl) |
+| [M5StickC Plus2](M5StickC-Plus2) | ESP32-PICO-V3-02 | 1.14" 240×135 LCD | Clarity (v1) | `m5stick-cplus2` | [AliExpress](https://s.click.aliexpress.com/e/_c3jkKlNj) |
+| [LilyGo T-Display S3](LilyGo-T-Display-S3) | ESP32-S3 | 1.9" 320×170 LCD | 🥭 **Mango (v2.1.1)** · tier L | `tdisplay-s3` | [AliExpress](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
+| [LilyGo T8 ESP32-S2](LilyGo-T8-ESP32-S2) | ESP32-S2 | 1.14" 135×240 LCD | Clarity (v1) | `t8-s2` | [AliExpress](https://s.click.aliexpress.com/e/_c2w1HnpJ) |
+| [Elecrow CrowPanel Advance 3.5"](CrowPanel-Advance-35) | ESP32-S3 | 3.5" 480×320 IPS touch | Clarity (v1) | `crowpanel-adv-35` | [AliExpress](https://s.click.aliexpress.com/e/_c4lDErmN) |
+| [LilyGo T-Display S3 AMOLED 1.91"](LilyGo-T-Display-S3-AMOLED) | ESP32-S3 | 1.91" 240×536 AMOLED | Clarity (v1) | `tdisplay-s3-amoled` | [AliExpress](https://s.click.aliexpress.com/e/_c3XNB9Hx) |
+| [TTGO T-Display ESP32](TTGO-T-Display-ESP32) | ESP32 | 1.14" 135×240 LCD | Clarity (v1) | `tdisplay-esp32` | [AliExpress](https://s.click.aliexpress.com/e/_c32HlGQ1) |
+| [ESP32-C3-OLED](ESP32-C3-OLED) | ESP32-C3 | 0.42" 72×40 OLED | Clarity (v1) | `esp32c3-oled` | [AliExpress](https://s.click.aliexpress.com/e/_c3JMxywv) |
+| M5Stack StickS3 | — | — | 🚧 in progress | — | [AliExpress](https://s.click.aliexpress.com/e/_c3ZsWHBB) |
+
+Plus any USB-C cable for flashing and power. Note that some cheap cables are **charge-only** — flashing needs a data cable.
+
+## Which one should I buy?
+
+- **Best overall:** [LilyGo T-Display S3](LilyGo-T-Display-S3) — the biggest small-format screen, two buttons, and the reference board for the [tier L](The-UI#display-tiers) Mango layout with the four model mascots.
+- **Smallest complete package:** [M5StickC Plus](M5StickC-Plus) — case, battery, and buttons included, zero soldering, and it runs Mango tier S.
+- **Cheapest:** [ESP32-C3-OLED](ESP32-C3-OLED) — but you wire your own buttons, and the 0.42" OLED shows a stripped-down layout.
+- **Biggest screen:** [CrowPanel Advance 3.5"](CrowPanel-Advance-35) — touch instead of buttons; still on the Clarity dashboard.
+
+## Board differences worth knowing
+
+Not every board can do everything. These limits come from the hardware, not the firmware:
+
+| Board | Battery readout | Factory reset on boot | Notes |
+| ----- | --------------- | --------------------- | ----- |
+| M5StickC Plus / Plus2 | ✅ | ✅ | Two buttons, internal battery |
+| LilyGo T-Display S3 | ✅ | ✅ | Two buttons |
+| TTGO T-Display | ✅ | ✅ | Two buttons |
+| LilyGo T8 ESP32-S2 | ❌ | ❌ | One button (short tap / long press) |
+| CrowPanel Advance 3.5" | ❌ | ❌ | Touch zones instead of buttons |
+| T-Display S3 AMOLED | varies | ✅ | Button B needs a touch-equipped variant |
+| ESP32-C3-OLED | ❌ | ✅ | You wire the buttons yourself |
+
+Where factory reset on boot isn't available, re-flash the board to wipe its stored credentials.
+
+## Adding a board
+
+New boards are welcome — see [Project structure](Project-Structure#adding-a-board) for what's involved.

--- a/wiki/TTGO-T-Display-ESP32.md
+++ b/wiki/TTGO-T-Display-ESP32.md
@@ -1,6 +1,6 @@
 # TTGO T-Display ESP32
 
-Part of [Claude Usage Stick](../README.md). The classic LilyGo/TTGO T-Display — an original ESP32 with a 1.14" ST7789 panel over 4-wire SPI and two front buttons.
+Part of [Claude Usage Stick](Home). The classic LilyGo/TTGO T-Display — an original ESP32 with a 1.14" ST7789 panel over 4-wire SPI and two front buttons.
 
 ## Specs
 
@@ -15,6 +15,10 @@ Part of [Claude Usage Stick](../README.md). The classic LilyGo/TTGO T-Display �
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c32HlGQ1) |
 
 ## Flash
+
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+
+From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 
 ```bash
 pio run -e tdisplay-esp32 -t upload     # firmware
@@ -33,3 +37,7 @@ pio run -e tdisplay-esp32 -t uploadfs   # web setup UI (SPIFFS)
 
 - Runs the original **Clarity** dashboard until it's migrated to the Mango tier S layout.
 - During setup, the WiFi AP password is shown on the device screen.
+
+---
+
+**TTGO T Display ESP32** · env `tdisplay-esp32` · [All boards](Supported-Boards) · [Flashing](Flashing) · [Setup and daily use](Setup-and-Daily-Use) · [Troubleshooting](Troubleshooting)

--- a/wiki/The-UI.md
+++ b/wiki/The-UI.md
@@ -1,0 +1,37 @@
+# The UI
+
+Firmware releases carry names. Which one your board runs is listed in [Supported boards](Supported-Boards).
+
+## Versions
+
+| Version | Name | Highlights |
+| ------- | ---- | ---------- |
+| v1 | **Clarity** | The original dashboard — usage bars, reset countdowns, PIN unlock, captive-portal setup |
+| v2 | 🥭 **Mango** | Everything in Clarity, plus model-status mascots, header icons, inline countdowns, and screen flip |
+
+Boards still on **Clarity** keep the original minimal dashboard until they're migrated to their tier.
+
+## Display tiers
+
+The Mango dashboard keeps the same header and usage bars on every board, and adapts only its bottom **MODELS** section to the screen size. Each tier has a reference board; the layout scales to fit.
+
+| Tier | Class | Resolution | Reference board | MODELS section | Status |
+| ---- | ----- | ---------- | --------------- | -------------- | ------ |
+| **XS** | tiny OLED | ≤ 128×64 | [ESP32-C3-OLED](ESP32-C3-OLED) | — | ⏳ Pending |
+| **S** | small LCD | ~240×135 | [M5StickC Plus](M5StickC-Plus) | One overall-health Clawd + a 2×2 `NAME UP/DOWN` text grid | ✅ |
+| **L** | large LCD | ~320×170 | [LilyGo T-Display S3](LilyGo-T-Display-S3) | A row of four labelled Clawds (one per model), each blinking when healthy | ✅ |
+| **XL** | big / touch | ≥ 480×320 | [CrowPanel 3.5"](CrowPanel-Advance-35), [S3 AMOLED](LilyGo-T-Display-S3-AMOLED) | — | ⏳ Pending |
+
+## What Mango adds
+
+- **Model status mascots** — Haiku / Sonnet / Opus / Fable health from the Claude status page; a downed model turns gray with X eyes, healthy ones blink
+- **Header icons** — battery level and WiFi signal strength as icons in the header bar
+- **Reset countdowns by tier** — tier S shows each reset time inline on its bar row; tier L (v2.1.1) gives the countdowns their own large-type row below the bars
+- **Dashboard-styled PIN screen** — the unlock screen matches the dashboard look
+- **Screen flip and brightness** — Button A flips the screen 180°, Button B cycles brightness; refresh happens automatically, or press **A+B** together to force one
+
+## Screens
+
+| Boot | PIN unlock | Dashboard |
+| --- | --- | --- |
+| <img src="https://raw.githubusercontent.com/oauramos/claude-usage-stick/main/assets/boot.jpg" width="240" alt="Boot screen"> | <img src="https://raw.githubusercontent.com/oauramos/claude-usage-stick/main/assets/pin.jpg" width="240" alt="PIN unlock screen"> | <img src="https://raw.githubusercontent.com/oauramos/claude-usage-stick/main/assets/dashboard.jpg" width="240" alt="Usage dashboard"> |

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -1,0 +1,65 @@
+# Troubleshooting
+
+## Flashing
+
+### The web flasher doesn't show a Connect button
+
+Web Serial only exists in **Chrome, Edge, and Opera on desktop**. Firefox and Safari don't implement it, and neither does any browser on iOS or Android. The page will say so rather than failing silently.
+
+### The board isn't in the serial-port list
+
+- Use a **data** USB-C cable. Charge-only cables are common and carry no data lines.
+- Hold the **BOOT** button while plugging the board in to force download mode.
+- On macOS and Windows, some boards need a USB-UART driver: **CH340/CH341** for the T8-S2, CrowPanel, and TTGO T-Display; **CP210x** for various others. Boards with native USB (ESP32-S3, C3) usually need nothing.
+
+### My board says "build pending"
+
+Its firmware image hasn't been published by CI. Build it from source instead — see [Flashing](Flashing#from-source).
+
+### `uploadfs` fails with "Bad CPU type" on a Mac
+
+The bundled mkspiffs binary is x86-only. Install Rosetta (`softwareupdate --install-rosetta`) or run the repo's `python3 upload_data.py` fallback.
+
+## WiFi and setup
+
+### I can't find the `ClaudeMonitor-XXXX` network
+
+Give the device 10–15 seconds after boot. If it never appears, it's probably already configured — factory reset it (hold **A+B** during boot) to return it to setup mode.
+
+### The setup page won't load
+
+Browse to **`http://192.168.4.1`** explicitly, with `http://`, not https. Turn off mobile data or any VPN first — phones often route the request to the cellular network instead of the device's AP.
+
+### It connects to WiFi, then drops
+
+ESP32 radios are **2.4 GHz only**. If your router advertises one name for both bands, the device may be handed a 5 GHz association it can't keep. Give the 2.4 GHz band its own SSID, or temporarily disable band steering while setting up.
+
+## Usage display
+
+### The device shows `no_usage_h_200`
+
+The request succeeded (HTTP 200), but the response carried **no unified usage headers**. This means the token is valid and the account is fine — but the plan behind it doesn't publish 5h/7d usage.
+
+**Enterprise and API-billed accounts don't emit these headers.** The device needs a token from a **Claude Pro or Max** subscription. Generate one with `claude setup-token` while signed into the subscription account, then redo [setup](Setup-and-Daily-Use).
+
+### Usage stays at 0%
+
+You genuinely haven't used any of the window yet, which is the happy case. If you have been working, check that the token belongs to the same account you're using Claude Code with.
+
+### The dashboard freezes or stops refreshing
+
+Check the WiFi icon in the header. If the signal dropped, the device retries on its own. If it stays stuck, power-cycle it — credentials survive a reboot, but you'll re-enter your PIN.
+
+## PIN
+
+### I forgot my PIN
+
+There's no recovery — that's the design, not an oversight. The PIN is never stored, so nothing on the device can verify or reveal it. Factory reset (hold **A+B** on boot, or re-flash on boards without that combo) and set it up again with a new token. See [Security](Security).
+
+### The device wiped itself
+
+Ten consecutive wrong PIN attempts trigger a full credential wipe. Set it up again from scratch.
+
+## Still stuck?
+
+Open an [issue](https://github.com/oauramos/claude-usage-stick/issues) with your board, the firmware version, and what the screen shows.

--- a/wiki/_Sidebar.md
+++ b/wiki/_Sidebar.md
@@ -1,0 +1,27 @@
+### [Claude Usage Stick](Home)
+
+**Using it**
+- [Features](Features)
+- [The UI](The-UI)
+- [Setup and daily use](Setup-and-Daily-Use)
+- [Troubleshooting](Troubleshooting)
+
+**Hardware**
+- [Supported boards](Supported-Boards)
+- [M5StickC Plus](M5StickC-Plus)
+- [M5StickC Plus2](M5StickC-Plus2)
+- [LilyGo T-Display S3](LilyGo-T-Display-S3)
+- [LilyGo T8 ESP32-S2](LilyGo-T8-ESP32-S2)
+- [CrowPanel Advance 3.5"](CrowPanel-Advance-35)
+- [T-Display S3 AMOLED](LilyGo-T-Display-S3-AMOLED)
+- [TTGO T-Display](TTGO-T-Display-ESP32)
+- [ESP32-C3-OLED](ESP32-C3-OLED)
+
+**Under the hood**
+- [Flashing](Flashing)
+- [How it works](How-It-Works)
+- [Security](Security)
+- [Project structure](Project-Structure)
+
+---
+⚡ [Web flasher](https://oauramos.github.io/claude-usage-stick/)


### PR DESCRIPTION
Follows #18 (now merged) — rebased onto `main`, so this diff is only the docs restructure.

## Why

The README had become the entire manual — features, UI tiers, quick start, security, project layout, gallery. All useful, but it buried the one thing a visitor actually wants: how to get a device running. 186 lines before you reach anything actionable.

## What changed

**README → landing page (186 → 65 lines).** Title, hero shot, one-paragraph description, then immediately the two paths: flash from the browser, or clone and build. Below that, a table linking into the wiki.

**`wiki/` → the manual,** organised by what the reader is doing rather than by what the code contains:

| Page | Covers |
| --- | --- |
| Features | What the device shows |
| The UI | Clarity/Mango versions, display tiers, screenshots |
| Supported boards | The lineup + a "which should I buy?" section + a hardware-limits table |
| Flashing | Web flasher and from-source, incl. the known env build failures |
| Setup and daily use | Captive portal, PIN, per-board control mappings, factory reset |
| How it works | The API request, the headers, plan requirements |
| Security | Token encryption, brute-force protection, threat model |
| Troubleshooting | **new** |
| Project structure | Repo layout, how to add a board |
| 8 board guides | Moved from `docs/`, one per board |

**`docs/` removed.** Its eight board pages are now wiki board guides, with intro links, image paths, and cross-references rewritten for the wiki (images use raw.githubusercontent URLs; `../README.md#display-tiers` became `The-UI#display-tiers`). Each guide now leads with the web flasher and keeps the PlatformIO commands underneath, and gained a footer nav row.

**Troubleshooting is new content**, collecting failure modes that were previously only known from experience: Web Serial browser support, charge-only USB cables, the Apple Silicon mkspiffs "Bad CPU type" failure, 2.4 GHz-only radios and band steering, forgotten PINs, and the `no_usage_h_200` case — where an Enterprise or API-billed token returns HTTP 200 with no unified usage headers and you need a Pro/Max token instead.

## Docs are versioned, not live-edited

Wiki pages are written in `wiki/` on `main`; `.github/workflows/wiki.yml` mirrors them into the wiki on merge. Documentation gets reviewed in PRs like any other change, and the content survives in the repo even if the wiki is wiped. The sync deletes upstream pages that no longer exist in `wiki/`, so it's a true mirror — editing a page in the wiki UI works, but the next sync overwrites it.

## ⚠️ One manual step before the wiki works

GitHub only creates the `.wiki.git` repository after the first page exists. **Open https://github.com/oauramos/claude-usage-stick/wiki, click "Create the first page", and save anything** — the sync will then overwrite it with the real content. Until that's done the workflow fails with an explicit error message telling you exactly this.

## Verified

- All 19 pages' internal links resolve to pages that exist (checked programmatically).
- No leftover `../` or `README.md` links in the migrated board guides.
- Ran the workflow's mirror logic against a simulated wiki repo: 19 pages published, a stale page correctly deleted, an outdated page updated.
- Both workflow files parse as valid YAML.
- Regenerated `web/index.html` after repointing the flasher's "Board docs" footer link at the wiki.

Not verified: the actual push to the wiki, which can't happen until the wiki is initialised.
