### PR TITLE
fix(m5stick-cplus2): unpin M5Unified, the exact version was yanked from the registry

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -28,7 +28,7 @@ board_build.filesystem = spiffs
 board_build.partitions = default.csv
 
 lib_deps =
-    m5stack/M5Unified@0.1.15
+    m5stack/M5Unified@^0.2.0
     bblanchon/ArduinoJson@^7.0.0
 
 build_flags =

--- a/wiki/Flashing.md
+++ b/wiki/Flashing.md
@@ -40,14 +40,11 @@ or use the Python fallback included in the repo:
 python3 upload_data.py
 ```
 
-### Known build issues
+### If a build fails
 
-Two envs currently fail to build in some environments for reasons unrelated to the firmware itself:
+All eight envs build in CI. If one fails locally, it's usually the toolchain rather than the firmware — a known one is **`tdisplay-s3-amoled`**, which can fail while generating `bootloader.bin` if the Python running PlatformIO lacks the `intelhex` module (`pip install intelhex`).
 
-- **`m5stick-cplus2`** — a dependency pin conflict
-- **`tdisplay-s3-amoled`** — an `intelhex` failure in the LilyGo AMOLED toolchain
-
-These are environmental, not regressions. When they fail in CI, the affected board simply shows as *build pending* on the web flasher; every other board still deploys.
+CI treats each board independently: a board that fails to build is left out of the deploy and shows as *build pending* on the web flasher, while every other board still ships.
 
 ## After flashing
 


### PR DESCRIPTION
Fixes the `firmware (m5stick-cplus2)` job, which has been red on every run since the flasher workflow landed ([example](https://github.com/oauramos/claude-usage-stick/actions/runs/33116631422/job/98672820099)).

## What's wrong

```
Library Manager: Installing m5stack/M5Unified @ 0.1.15
UnknownPackageError: Could not find the package with 'm5stack/M5Unified @ 0.1.15' requirements
```

It fails at dependency resolution, before a single source file is compiled. `0.1.15` has been removed from the PlatformIO registry — the oldest 0.1.x still published is `0.1.14`, and the library has long since moved to 0.2.x (`0.2.21` as of today).

The root cause isn't really the missing version, it's the **exact pin**. Pinning one patch release means any upstream yank breaks the build with no resolution path, which is exactly what happened.

## The fix

```diff
-    m5stack/M5Unified@0.1.15
+    m5stack/M5Unified@^0.2.0
```

A caret range matches how every other dependency in `platformio.ini` is constrained (`ArduinoJson@^7.0.0`, `TFT_eSPI@^2.5.0`, `U8g2@^2.36.5`, …), so the resolver takes the newest compatible 0.2.x and a future yank can't reproduce this.

## Is 0.2.x API-compatible?

The firmware uses only the stable core of M5Unified — checked every call site in `src/hal.cpp`:

| Call | Present in 0.2.21 |
| --- | --- |
| `M5.config()` / `M5.begin(cfg)` / `M5.update()` | ✅ `M5Unified.cpp` |
| `M5.BtnA/BtnB.wasPressed()` / `.isPressed()` | ✅ `utility/Button_Class.hpp` |
| `M5.Power.getBatteryLevel()` / `.getBatteryVoltage()` | ✅ `utility/Power_Class.hpp` |
| `M5.Display.setBrightness()` | ✅ `M5Unified.hpp` |

None of these changed across the 0.1 → 0.2 transition.

## Verified

Clean build with `.pio/libdeps/m5stick-cplus2` wiped, so dependency resolution ran from scratch:

- resolves **M5Unified 0.2.21**
- compiles and links with no errors or warnings from the bump
- produces `bootloader.bin`, `partitions.bin`, `firmware.bin`

Not verified: running it on an actual M5StickC Plus2, which needs the hardware. The change is a dependency version, and the code path it feeds is unchanged, but a smoke test on a real board before trusting the published image would be sensible.

## Docs

`wiki/Flashing.md` listed this as one of two "known build issues … environmental, not regressions". That was wrong about this one — it was a real repo bug, and it broke CI too. The section is rewritten to say all eight envs build, and to keep only the genuinely local AMOLED `intelhex` case (with its one-line fix).

After this merges, all eight boards should publish firmware and **M5StickC Plus2 stops showing "build pending"** on the flasher.
