### PR TITLE
feat(tdisplay-s3): v3 platform base — 16MB partitions, PSRAM, WiFi-first boot

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -95,7 +95,11 @@ framework = arduino
 monitor_speed = 115200
 upload_speed = 921600
 board_build.filesystem = spiffs
-board_build.partitions = default.csv
+; 16MB chip (the board default); the 4MB table capped the app at 1.25MB, which
+; v3 outgrew. Flash offsets of the 4 web-flasher artifacts are identical in
+; both tables and NVS stays at 0x9000, so settings survive a reflash.
+board_build.partitions = default_16MB.csv
+board_build.arduino.memory_type = qio_opi
 
 lib_deps =
     bodmer/TFT_eSPI@^2.5.0
@@ -104,6 +108,7 @@ lib_deps =
 build_flags =
     -DBOARD_TDISPLAY_S3
     -DMANGO_UI
+    -DBOARD_HAS_PSRAM
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DUSER_SETUP_LOADED
     -DST7789_DRIVER

--- a/src/app_state.h
+++ b/src/app_state.h
@@ -1,0 +1,18 @@
+#pragma once
+#include "api.h"
+#include "settings.h"
+#ifdef MANGO_UI
+#include "status.h"
+#endif
+
+// Shared app state, defined in main.cpp. The web panel reads and writes these
+// from HTTP handlers; everything runs on the single Arduino loop task, so no
+// locking is needed.
+extern Settings      g_settings;
+extern UsageData     g_usage;
+#ifdef MANGO_UI
+extern ModelStatus   g_models;
+#endif
+extern char          g_token[256];      // decrypted OAuth token, RAM only
+extern bool          g_unlocked;        // PIN accepted (buttons or web)
+extern unsigned long g_lastFetchMs;

--- a/src/config.h
+++ b/src/config.h
@@ -1,7 +1,9 @@
 #pragma once
 
 // ── Firmware version ─────────────────────────────────────
-#define FW_VERSION              "2.1.1"  // Mango — shown on the Mango boot screen
+// "-dev" marks pre-release main-branch builds (the web flasher publishes every
+// merge); the suffix drops in the release PR.
+#define FW_VERSION              "3.0.0-dev"  // Dust — shown on the Mango boot screen
 
 // ── Polling ──────────────────────────────────────────────
 #define DEFAULT_POLL_SEC        120

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -7,6 +7,10 @@
  * Dashboard (Mango):   A flips the screen, B cycles brightness, A+B force refresh
  * A+B held on boot: factory reset → wipe NVS → re-enter setup
  *
+ * Boot order differs per board: the T-Display S3 brings WiFi up before the PIN
+ * (the LAN address is shown while locked, and a failed connect falls back to a
+ * WiFi-reconfigure portal); every other board keeps the PIN-first order.
+ *
  * ESP32-C3-OLED wiring (both buttons external, active-LOW to GND):
  *   Button A → GPIO 3     Button B → GPIO 7
  *   SDA → GPIO 5          SCL → GPIO 6
@@ -15,9 +19,10 @@
 
 #include "hal.h"
 #include <WiFi.h>
-#include <Preferences.h>
 #include "config.h"
 #include "crypto.h"
+#include "settings.h"
+#include "app_state.h"
 #include "provision.h"
 #include "api.h"
 #include "ui.h"
@@ -25,15 +30,14 @@
 #include "status.h"
 #endif
 
-static Preferences prefs;
-static char        token[256];
-static UsageData   usage;
+Settings      g_settings;
+UsageData     g_usage;
 #ifdef MANGO_UI
-static ModelStatus modelStatus = {true, true, true, true, false};
+ModelStatus   g_models = {true, true, true, true, false};
 #endif
-static unsigned long lastFetch = 0;
-static int         pollMs     = DEFAULT_POLL_SEC * 1000;
-static uint8_t     brightness = DEFAULT_BRIGHTNESS;
+char          g_token[256];
+bool          g_unlocked = false;
+unsigned long g_lastFetchMs = 0;
 
 // ── PIN Entry (blocks until 4 digits confirmed) ────────
 static void enterPin(char* pinOut, int maxLen) {
@@ -66,6 +70,26 @@ static bool connectWiFi(const char* ssid, const char* pass) {
     return true;
 }
 
+// ── Setup-AP credentials (also used by the WiFi recovery portal) ──
+static void makeApCreds(char* apName, size_t nameLen, char* apPass, size_t passLen) {
+    uint8_t mac[6];
+    esp_efuse_mac_get_default(mac);
+    snprintf(apName, nameLen, "ClaudeMonitor-%02X%02X", mac[4], mac[5]);
+
+#ifdef BOARD_ESP32C3_OLED
+    // No readable display during setup — use open AP so password isn't needed
+    apPass[0] = '\0';
+    Serial.printf("[SETUP] AP: %s (open)\n", apName);
+#else
+    static const char alphabet[] = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+    uint8_t rnd[8];
+    esp_fill_random(rnd, sizeof(rnd));
+    size_t n = (passLen > 9) ? 8 : passLen - 1;
+    for (size_t i = 0; i < n; i++) apPass[i] = alphabet[rnd[i] % (sizeof(alphabet) - 1)];
+    apPass[n] = '\0';
+#endif
+}
+
 // ── Sync NTP for reset countdown display ───────────────
 static void syncTime() {
     configTime(0, 0, "pool.ntp.org", "time.nist.gov");
@@ -76,19 +100,94 @@ static void syncTime() {
 // ── Fetch + draw ───────────────────────────────────────
 static void refresh() {
     if (WiFi.status() != WL_CONNECTED) {
-        prefs.begin(NVS_NAMESPACE, true);
-        connectWiFi(prefs.getString("ssid", "").c_str(),
-                    prefs.getString("wifipass", "").c_str());
-        prefs.end();
+        connectWiFi(g_settings.ssid, g_settings.wifipass);
     }
-    fetchUsage(token, usage);
+    fetchUsage(g_token, g_usage);
 #ifdef MANGO_UI
-    fetchModelStatus(modelStatus);   // failure keeps last-known state
-    uiSetModelStatus(modelStatus);
+    fetchModelStatus(g_models);   // failure keeps last-known state
+    uiSetModelStatus(g_models);
 #endif
-    lastFetch = millis();
-    uiDashboard(usage, lastFetch, WiFi.RSSI(), halBatPercent());
+    g_lastFetchMs = millis();
+    uiDashboard(g_usage, g_lastFetchMs, WiFi.RSSI(), halBatPercent());
 }
+
+// ── Boot phases ────────────────────────────────────────
+// PIN + decrypt loop: 10 attempts wipe the credentials, lockout doubles.
+static void unlockPhase(int progressPct) {
+    uiBootProgress(progressPct, "Enter PIN...");
+    delay(300);
+
+    int attempts = 0;
+    while (attempts < MAX_PIN_ATTEMPTS) {
+        char pin[9];
+        enterPin(pin, sizeof(pin));
+
+        if (decryptToken(g_settings.blob, pin, g_token, sizeof(g_token))) break;
+
+        attempts++;
+        if (attempts >= MAX_PIN_ATTEMPTS) {
+            uiError("MAX ATTEMPTS", "Wiping credentials...");
+            settingsWipeAll();
+            delay(3000);
+            ESP.restart();
+        }
+
+        int lockSec = LOCKOUT_BASE_SEC * (1 << (attempts - 1));
+        if (lockSec > 3600) lockSec = 3600;
+        uiLockoutStatic(attempts, MAX_PIN_ATTEMPTS, lockSec);
+        for (int s = lockSec; s > 0; s--) {
+            uiLockoutTick(s);
+            delay(1000);
+        }
+    }
+    g_unlocked = true;
+}
+
+#ifdef BOARD_TDISPLAY_S3
+// WiFi before the PIN on this board: the creds need no PIN, and the device's
+// LAN address is already known (and shown) while it sits locked. A dead network
+// lands in the reconfigure portal instead of the old infinite reboot loop.
+static void netPhase() {
+    char host[33];
+    slugifyHostname(g_settings.devName, host, sizeof(host));
+    WiFi.mode(WIFI_STA);
+    WiFi.setHostname(host);   // must precede WiFi.begin to land in the DHCP lease
+
+    uiBootProgress(60, "Connecting WiFi...");
+    int tries = 0;
+    while (!connectWiFi(g_settings.ssid, g_settings.wifipass)) {
+        if (++tries >= 3) {
+            char apName[24], apPass[9];
+            makeApCreds(apName, sizeof(apName), apPass, sizeof(apPass));
+            runProvisioningPortal(apName, apPass, true);   // never returns
+        }
+        uiError("WIFI FAILED", "Retrying...");
+        delay(2000);
+    }
+
+    uiBootProgress(70, "Syncing time...");
+    syncTime();
+    settingsApplyTZ(g_settings.tzMin);
+
+    char url[40];
+    snprintf(url, sizeof(url), "http://%s", WiFi.localIP().toString().c_str());
+    uiSetNetInfo(url);
+    uiSetHeaderLabel(g_settings.devName);
+}
+#else
+static void netPhaseLegacy() {
+    uiBootProgress(80, "Connecting WiFi...");
+    if (!connectWiFi(g_settings.ssid, g_settings.wifipass)) {
+        uiError("WIFI FAILED", g_settings.ssid);
+        delay(5000);
+        ESP.restart();
+    }
+
+    uiBootProgress(90, "Syncing time...");
+    syncTime();
+    settingsApplyTZ(g_settings.tzMin);
+}
+#endif
 
 // ── Setup ──────────────────────────────────────────────
 void setup() {
@@ -115,41 +214,19 @@ void setup() {
         }
         if (held) {
             uiBootProgress(50, "Factory reset...");
-            prefs.begin(NVS_NAMESPACE, false);
-            prefs.clear();
-            prefs.end();
+            settingsWipeAll();
             uiError("NVS WIPED", "Rebooting in 2s...");
             delay(2000);
             ESP.restart();
         }
     }
 
-    // Check provisioned
-    prefs.begin(NVS_NAMESPACE, true);
-    bool provisioned = prefs.getBool("provisioned", false);
-    prefs.end();
-
-    if (!provisioned) {
+    if (!settingsIsProvisioned()) {
         uiBootProgress(50, "No config found");
         delay(400);
 
-        uint8_t mac[6];
-        esp_efuse_mac_get_default(mac);
-        char apName[24];
-        snprintf(apName, sizeof(apName), "ClaudeMonitor-%02X%02X", mac[4], mac[5]);
-
-#ifdef BOARD_ESP32C3_OLED
-        // No readable display during setup — use open AP so password isn't needed
-        const char* apPass = "";
-        Serial.printf("[SETUP] AP: %s (open)\n", apName);
-#else
-        static const char alphabet[] = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
-        uint8_t rnd[8];
-        esp_fill_random(rnd, sizeof(rnd));
-        char apPass[9];
-        for (int i = 0; i < 8; i++) apPass[i] = alphabet[rnd[i] % (sizeof(alphabet) - 1)];
-        apPass[8] = '\0';
-#endif
+        char apName[24], apPass[9];
+        makeApCreds(apName, sizeof(apName), apPass, sizeof(apPass));
         runProvisioningPortal(apName, apPass);
         return;
     }
@@ -157,54 +234,19 @@ void setup() {
     uiBootProgress(50, "Config loaded");
     delay(200);
 
-    // Load NVS
-    prefs.begin(NVS_NAMESPACE, true);
-    String ssid = prefs.getString("ssid", "");
-    String pass = prefs.getString("wifipass", "");
-    EncryptedBlob blob;
-    prefs.getBytes("blob", &blob, sizeof(blob));
-    pollMs     = prefs.getInt("poll_sec", DEFAULT_POLL_SEC) * 1000;
-    brightness = prefs.getInt("brightness", DEFAULT_BRIGHTNESS);
-    prefs.end();
+    settingsLoad(g_settings);
+    halSetBrightness(g_settings.brightness);
+#ifdef MANGO_UI
+    if (g_settings.flip) uiApplyRotation(true);
+#endif
 
-    halSetBrightness(brightness);
-
-    uiBootProgress(60, "Enter PIN...");
-    delay(300);
-
-    // PIN + decrypt loop
-    int attempts = 0;
-    while (attempts < MAX_PIN_ATTEMPTS) {
-        char pin[9];
-        enterPin(pin, sizeof(pin));
-
-        if (decryptToken(blob, pin, token, sizeof(token))) break;
-
-        attempts++;
-        if (attempts >= MAX_PIN_ATTEMPTS) {
-            uiError("MAX ATTEMPTS", "Wiping credentials...");
-            prefs.begin(NVS_NAMESPACE, false);
-            prefs.clear();
-            prefs.end();
-            delay(3000);
-            ESP.restart();
-        }
-
-        int lockSec = LOCKOUT_BASE_SEC * (1 << (attempts - 1));
-        if (lockSec > 3600) lockSec = 3600;
-        uiLockout(attempts, MAX_PIN_ATTEMPTS, lockSec);
-    }
-
-    uiBootProgress(80, "Connecting WiFi...");
-
-    if (!connectWiFi(ssid.c_str(), pass.c_str())) {
-        uiError("WIFI FAILED", ssid.c_str());
-        delay(5000);
-        ESP.restart();
-    }
-
-    uiBootProgress(90, "Syncing time...");
-    syncTime();
+#ifdef BOARD_TDISPLAY_S3
+    netPhase();
+    unlockPhase(85);
+#else
+    unlockPhase(60);
+    netPhaseLegacy();
+#endif
 
     uiBootProgress(95, "Fetching usage...");
     refresh();
@@ -229,21 +271,25 @@ void loop() {
         refresh();
     } else if (aPressAt && millis() - aPressAt > comboWindowMs) {
         aPressAt = 0;
-        uiToggleRotation();
-        uiDashboard(usage, lastFetch, WiFi.RSSI(), halBatPercent());
+        g_settings.flip = !g_settings.flip;
+        uiApplyRotation(g_settings.flip);
+        settingsPutU8("flip", g_settings.flip);
+        uiDashboard(g_usage, g_lastFetchMs, WiFi.RSSI(), halBatPercent());
     } else if (bPressAt && millis() - bPressAt > comboWindowMs) {
         bPressAt = 0;
-        brightness = (brightness + 1) % 4;
-        halSetBrightness(brightness);
+        g_settings.brightness = (g_settings.brightness + 1) % 4;
+        halSetBrightness(g_settings.brightness);
+        settingsPutInt("brightness", g_settings.brightness);
     }
 #else
     if (halBtnAWasPressed()) {
 #ifdef BOARD_ESP32C3_OLED
-        brightness = (brightness + 1) % 2; // on/off only — contrast change imperceptible
+        g_settings.brightness = (g_settings.brightness + 1) % 2; // on/off only — contrast change imperceptible
 #else
-        brightness = (brightness + 1) % 4;
+        g_settings.brightness = (g_settings.brightness + 1) % 4;
 #endif
-        halSetBrightness(brightness);
+        halSetBrightness(g_settings.brightness);
+        settingsPutInt("brightness", g_settings.brightness);
     }
 
     if (halBtnBWasPressed()) {
@@ -251,7 +297,7 @@ void loop() {
     }
 #endif
 
-    if (millis() - lastFetch >= (unsigned long)pollMs) {
+    if (millis() - g_lastFetchMs >= (unsigned long)g_settings.pollSec * 1000UL) {
         refresh();
     }
 
@@ -262,7 +308,7 @@ void loop() {
     if (eyesClosed && millis() - lastBlink > 150) {
         uiBlinkTick(false);
         eyesClosed = false;
-    } else if (!eyesClosed && usage.ok && millis() - lastBlink > 2000) {
+    } else if (!eyesClosed && g_usage.ok && millis() - lastBlink > 2000) {
         uiBlinkTick(true);
         eyesClosed = true;
         lastBlink = millis();
@@ -273,7 +319,7 @@ void loop() {
     if (millis() - lastRedraw > 10000) {
         // Only time passed (not data) — update the clock/countdowns in place; redrawing
         // the whole dashboard here is what made the slow CrowPanel panel flicker.
-        uiDashboardClock(usage, lastFetch, WiFi.RSSI());
+        uiDashboardClock(g_usage, g_lastFetchMs, WiFi.RSSI());
         lastRedraw = millis();
     }
 

--- a/src/provision.cpp
+++ b/src/provision.cpp
@@ -12,6 +12,7 @@ static WebServer  webServer(80);
 static DNSServer  dnsServer;
 static Preferences prefs;
 static const byte DNS_PORT = 53;
+static bool       s_reconfig = false;
 
 static const char SETUP_HTML[] PROGMEM = R"rawhtml(<!DOCTYPE html>
 <html lang="en">
@@ -86,6 +87,7 @@ static const char SETUP_HTML[] PROGMEM = R"rawhtml(<!DOCTYPE html>
       <div class="warn">PIN is never stored anywhere. Forget it = factory reset.</div>
     </div>
 
+    <div id="prefs">
     <div class="divider"></div>
     <div class="section-label">Preferences</div>
 
@@ -114,6 +116,7 @@ static const char SETUP_HTML[] PROGMEM = R"rawhtml(<!DOCTYPE html>
       <input id="device_name" name="device_name" maxlength="32"
              placeholder="Claude Monitor" autocomplete="off">
     </div>
+    </div>
 
     <button type="submit" id="btn">Save & Reboot Device</button>
     <div id="status"></div>
@@ -133,6 +136,14 @@ document.getElementById('f').addEventListener('submit',async(e)=>{
     else{st.className='err';st.textContent='Error: '+await r.text();btn.disabled=false;}
   }catch(x){st.className='ok';st.textContent='Device rebooting (connection closed).';}
 });
+fetch('/portal-info').then(r=>r.json()).then(i=>{
+  if(!i.reconfig)return;
+  document.querySelector('h1').textContent='Reconnect WiFi';
+  document.querySelector('.sub').textContent='Update the WiFi details below. Token, PIN and preferences are kept unless you enter new credentials.';
+  document.getElementById('token').required=false;
+  document.getElementById('pin').required=false;
+  document.getElementById('prefs').style.display='none';
+}).catch(()=>{});
 </script>
 </body>
 </html>)rawhtml";
@@ -154,28 +165,36 @@ static void handleProvision() {
     // else would encrypt a token that can never be unlocked.
     bool pinOk = pin.length() == 4;
     for (size_t i = 0; pinOk && i < 4; i++) pinOk = isDigit(pin[i]);
-    if (ssid.isEmpty() || token.isEmpty() || !pinOk) {
-        webServer.send(400, "text/plain", "Missing fields, or PIN is not exactly 4 digits.");
+
+    // Reconfigure mode: token + PIN both empty means "keep the stored blob".
+    bool keepBlob = s_reconfig && token.isEmpty() && pin.isEmpty();
+    if (ssid.isEmpty() || (!keepBlob && (token.isEmpty() || !pinOk))) {
+        webServer.send(400, "text/plain", s_reconfig
+            ? "SSID is required. To replace the token, fill in both token and a 4-digit PIN; leave both empty to keep the stored one."
+            : "Missing fields, or PIN is not exactly 4 digits.");
         return;
     }
 
     EncryptedBlob blob;
-    if (!encryptToken(token.c_str(), pin.c_str(), blob)) {
+    if (!keepBlob && !encryptToken(token.c_str(), pin.c_str(), blob)) {
         webServer.send(500, "text/plain", "Encryption failed.");
         return;
     }
 
-    int pollSec = pollStr.isEmpty() ? DEFAULT_POLL_SEC : constrain(pollStr.toInt(), MIN_POLL_SEC, MAX_POLL_SEC);
-    int bright  = brightStr.isEmpty() ? DEFAULT_BRIGHTNESS : constrain(brightStr.toInt(), 0, 3);
-    if (nameStr.isEmpty()) nameStr = "Claude Monitor";
-
     prefs.begin(NVS_NAMESPACE, false);
     prefs.putString("ssid", ssid);
     prefs.putString("wifipass", wifipass);
-    prefs.putBytes("blob", &blob, sizeof(blob));
-    prefs.putInt("poll_sec", pollSec);
-    prefs.putInt("brightness", bright);
-    prefs.putString("dev_name", nameStr);
+    if (!keepBlob) prefs.putBytes("blob", &blob, sizeof(blob));
+    if (!s_reconfig) {
+        // First-run setup records the preferences too; the reconfigure portal
+        // hides that section and leaves them untouched.
+        int pollSec = pollStr.isEmpty() ? DEFAULT_POLL_SEC : constrain(pollStr.toInt(), MIN_POLL_SEC, MAX_POLL_SEC);
+        int bright  = brightStr.isEmpty() ? DEFAULT_BRIGHTNESS : constrain(brightStr.toInt(), 0, 3);
+        if (nameStr.isEmpty()) nameStr = "Claude Monitor";
+        prefs.putInt("poll_sec", pollSec);
+        prefs.putInt("brightness", bright);
+        prefs.putString("dev_name", nameStr);
+    }
     prefs.putBool("provisioned", true);
     prefs.end();
 
@@ -184,12 +203,18 @@ static void handleProvision() {
     ESP.restart();
 }
 
+static void handlePortalInfo() {
+    webServer.send(200, "application/json",
+                   s_reconfig ? "{\"reconfig\":true}" : "{\"reconfig\":false}");
+}
+
 static void handleNotFound() {
     webServer.sendHeader("Location", "http://192.168.4.1/", true);
     webServer.send(302, "text/plain", "");
 }
 
-void runProvisioningPortal(const char* apName, const char* apPass) {
+void runProvisioningPortal(const char* apName, const char* apPass, bool reconfigure) {
+    s_reconfig = reconfigure;
     WiFi.mode(WIFI_AP);
     WiFi.softAP(apName, apPass);
     delay(100);
@@ -198,10 +223,11 @@ void runProvisioningPortal(const char* apName, const char* apPass) {
 
     webServer.on("/", HTTP_GET, handleRoot);
     webServer.on("/provision", HTTP_POST, handleProvision);
+    webServer.on("/portal-info", HTTP_GET, handlePortalInfo);
     webServer.onNotFound(handleNotFound);
     webServer.begin();
 
-    uiSetupScreen(apName, apPass);
+    uiSetupScreen(apName, apPass, reconfigure);
 
     while (true) {
         dnsServer.processNextRequest();

--- a/src/provision.h
+++ b/src/provision.h
@@ -2,4 +2,7 @@
 
 // Starts WiFi AP, serves captive portal at 192.168.4.1.
 // Blocks until user submits config. Encrypts token, saves to NVS, reboots.
-void runProvisioningPortal(const char* apName, const char* apPass);
+// With reconfigure=true (device already provisioned, WiFi unreachable) the
+// portal updates only the WiFi credentials by default: token/PIN may be left
+// empty to keep the stored blob, and preferences are not touched.
+void runProvisioningPortal(const char* apName, const char* apPass, bool reconfigure = false);

--- a/src/settings.cpp
+++ b/src/settings.cpp
@@ -1,0 +1,88 @@
+#include "settings.h"
+#include "config.h"
+#include <Arduino.h>
+#include <Preferences.h>
+#include <time.h>
+
+static Preferences prefs;
+
+bool settingsIsProvisioned() {
+    prefs.begin(NVS_NAMESPACE, true);
+    bool p = prefs.getBool("provisioned", false);
+    prefs.end();
+    return p;
+}
+
+void settingsLoad(Settings& s) {
+    memset(&s, 0, sizeof(s));
+    prefs.begin(NVS_NAMESPACE, true);
+    prefs.getString("ssid", s.ssid, sizeof(s.ssid));
+    prefs.getString("wifipass", s.wifipass, sizeof(s.wifipass));
+    s.hasBlob    = prefs.getBytes("blob", &s.blob, sizeof(s.blob)) == sizeof(s.blob);
+    s.pollSec    = constrain(prefs.getInt("poll_sec", DEFAULT_POLL_SEC), MIN_POLL_SEC, MAX_POLL_SEC);
+    s.brightness = constrain(prefs.getInt("brightness", DEFAULT_BRIGHTNESS), 0, 3);
+    prefs.getString("dev_name", s.devName, sizeof(s.devName));
+    s.tzMin      = constrain(prefs.getInt("tz_min", 0), -840, 840);
+    s.flip       = prefs.getUChar("flip", 0) ? 1 : 0;
+    prefs.end();
+}
+
+void settingsPutInt(const char* key, int32_t v) {
+    prefs.begin(NVS_NAMESPACE, false);
+    prefs.putInt(key, v);
+    prefs.end();
+}
+
+void settingsPutU8(const char* key, uint8_t v) {
+    prefs.begin(NVS_NAMESPACE, false);
+    prefs.putUChar(key, v);
+    prefs.end();
+}
+
+void settingsPutStr(const char* key, const char* v) {
+    prefs.begin(NVS_NAMESPACE, false);
+    prefs.putString(key, v);
+    prefs.end();
+}
+
+void settingsPutBlob(const char* key, const void* data, size_t len) {
+    prefs.begin(NVS_NAMESPACE, false);
+    prefs.putBytes(key, data, len);
+    prefs.end();
+}
+
+void settingsWipeAll() {
+    prefs.begin(NVS_NAMESPACE, false);
+    prefs.clear();
+    prefs.end();
+}
+
+void settingsApplyTZ(int32_t tzMin) {
+    int32_t m = -tzMin;   // POSIX sign inversion
+    char tz[16];
+    snprintf(tz, sizeof(tz), "GMT%c%ld:%02ld",
+             (m < 0) ? '-' : '+', labs((long)m) / 60, labs((long)m) % 60);
+    setenv("TZ", tz, 1);
+    tzset();
+}
+
+void slugifyHostname(const char* devName, char* out, size_t outLen) {
+    size_t n = 0;
+    bool dash = true;   // suppresses a leading dash
+    for (const char* p = devName; *p && n + 1 < outLen; p++) {
+        char c = *p;
+        if (c >= 'A' && c <= 'Z') c += 32;
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9')) {
+            out[n++] = c;
+            dash = false;
+        } else if (!dash) {
+            out[n++] = '-';
+            dash = true;
+        }
+    }
+    while (n > 0 && out[n - 1] == '-') n--;
+    out[n] = '\0';
+    if (n == 0 || strcmp(out, "claude-monitor") == 0) {
+        strlcpy(out, "claude-usage-stick", outLen);
+    }
+}

--- a/src/settings.h
+++ b/src/settings.h
@@ -1,0 +1,38 @@
+#pragma once
+#include <stdint.h>
+#include <stddef.h>
+#include "crypto.h"
+
+// All NVS access lives here (namespace "claude", NVS_NAMESPACE in config.h).
+// v1/v2 keys keep their original Preferences types — poll_sec and brightness
+// are i32 — because writing a different type to an existing key fails with
+// ESP_ERR_NVS_TYPE_MISMATCH. New keys added in v3 use u8/i32 as noted.
+struct Settings {
+    char          ssid[33];
+    char          wifipass[65];
+    EncryptedBlob blob;
+    bool          hasBlob;
+    int32_t       pollSec;      // i32, 30..300
+    uint8_t       brightness;   // stored as i32, 0..3
+    char          devName[33];
+    int32_t       tzMin;        // i32, minutes east of UTC, -840..840
+    uint8_t       flip;         // u8, persisted 180° screen rotation
+};
+
+bool settingsIsProvisioned();
+void settingsLoad(Settings& s);
+void settingsPutInt(const char* key, int32_t v);
+void settingsPutU8(const char* key, uint8_t v);
+void settingsPutStr(const char* key, const char* v);
+void settingsPutBlob(const char* key, const void* data, size_t len);
+void settingsWipeAll();
+
+// Sets the process TZ from an east-of-UTC minute offset. POSIX inverts the
+// sign (TZ=GMT-3 means UTC+3); the inversion happens here so callers think in
+// normal GMT± terms. Fixed offset only, no DST rules.
+void settingsApplyTZ(int32_t tzMin);
+
+// Device name → mDNS/DHCP hostname: lowercase [a-z0-9-], symbol runs collapsed
+// to one dash. Empty or the portal default ("Claude Monitor") falls back to
+// "claude-usage-stick".
+void slugifyHostname(const char* devName, char* out, size_t outLen);

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -80,11 +80,13 @@ void uiBootProgress(int percent, const char* label) {
     u8g2.sendBuffer();
 }
 
-void uiSetupScreen(const char* apName, const char* apPass) {
+void uiSetupScreen(const char* apName, const char* apPass, bool reconfigure) {
     u8g2.clearBuffer();
     u8g2.setFont(u8g2_font_4x6_tr);
 
-    // Header centred — "SETUP MODE" = 10 chars × 4px = 40px → x=16
+    // Header centred — "SETUP MODE" = 10 chars × 4px = 40px → x=16.
+    // No room for a reconfigure variant on 72×40; the portal page says it.
+    (void)reconfigure;
     oledStr(16, 6, "SETUP MODE");
     oledHLine(0, 8, 72);
 
@@ -242,28 +244,34 @@ void uiError(const char* title, const char* detail) {
     u8g2.sendBuffer();
 }
 
-void uiLockout(int attempts, int maxAttempts, int lockoutSec) {
+// The OLED redraws its whole frame each tick, so Static only latches the
+// attempt counts the ticks need.
+static int s_lockAttempts = 0, s_lockMax = 0;
+
+void uiLockoutStatic(int attempts, int maxAttempts, int lockoutSec) {
+    (void)lockoutSec;
+    s_lockAttempts = attempts;
+    s_lockMax      = maxAttempts;
+}
+
+void uiLockoutTick(int secondsLeft) {
     u8g2.setFont(u8g2_font_5x7_tr);
+    u8g2.clearBuffer();
 
-    for (int s = lockoutSec; s > 0; s--) {
-        u8g2.clearBuffer();
+    // "WRONG PIN" centred — 9 chars × 5px = 45px → x=13
+    oledStr(13, 10, "WRONG PIN");
 
-        // "WRONG PIN" centred — 9 chars × 5px = 45px → x=13
-        oledStr(13, 10, "WRONG PIN");
+    char atbuf[12];
+    snprintf(atbuf, sizeof(atbuf), "%d / %d", s_lockAttempts, s_lockMax);
+    int aw = u8g2.getStrWidth(atbuf);
+    oledStr((72 - aw) / 2, 22, atbuf);
 
-        char atbuf[12];
-        snprintf(atbuf, sizeof(atbuf), "%d / %d", attempts, maxAttempts);
-        int aw = u8g2.getStrWidth(atbuf);
-        oledStr((72 - aw) / 2, 22, atbuf);
+    char cbuf[12];
+    snprintf(cbuf, sizeof(cbuf), "Wait %ds", secondsLeft);
+    int cw = u8g2.getStrWidth(cbuf);
+    oledStr((72 - cw) / 2, 35, cbuf);
 
-        char cbuf[12];
-        snprintf(cbuf, sizeof(cbuf), "Wait %ds", s);
-        int cw = u8g2.getStrWidth(cbuf);
-        oledStr((72 - cw) / 2, 35, cbuf);
-
-        u8g2.sendBuffer();
-        delay(1000);
-    }
+    u8g2.sendBuffer();
 }
 
 void uiDashboardClock(const UsageData& data, unsigned long lastFetchMs, int rssi) {
@@ -386,14 +394,40 @@ void uiSetModelStatus(const ModelStatus& s) {
     s_modelStatus = s;
 }
 
-void uiToggleRotation() {
-    static bool flipped = false;
-    flipped = !flipped;
+void uiApplyRotation(bool flipped) {
     // 1 and 3 are the two landscape orientations; XOR-2 toggles between them
     // regardless of which one is this board's default (S3 = 1, M5StickC Plus = 3).
     lcd.setRotation(flipped ? (SCREEN_ROT ^ 2) : SCREEN_ROT);
     halClear(C_BG);
 }
+
+#ifdef BOARD_TDISPLAY_S3
+// The header's left text alternates between the device label and the panel URL
+// on the 10s clock tick. Both strings print opaque at a fixed width so each
+// phase fully covers the other without a fillRect (no flicker). 28 chars stops
+// short of the right cluster's worst-case extent (~x187).
+static char s_netUrl[40]      = "";
+static char s_hdrLabel[29]    = "CLAUDE USAGE";
+static bool s_hdrShowUrl      = false;
+
+void uiSetNetInfo(const char* url) {
+    strlcpy(s_netUrl, url, sizeof(s_netUrl));
+}
+
+void uiSetHeaderLabel(const char* name) {
+    if (!name || !name[0]) return;
+    strlcpy(s_hdrLabel, name, sizeof(s_hdrLabel));
+    for (char* p = s_hdrLabel; *p; p++) *p = toupper((unsigned char)*p);
+}
+
+template <class GFX>
+static void drawHeaderLeft(GFX& g) {
+    g.setTextColor(C_TEXT, C_HEAD);
+    g.setTextSize(1);
+    g.setCursor(4, 5);
+    g.printf("%-28.28s", (s_hdrShowUrl && s_netUrl[0]) ? s_netUrl : s_hdrLabel);
+}
+#endif // BOARD_TDISPLAY_S3
 
 // Clawd, 18x5 px (MSB = leftmost column). The row-1 gaps at cols 5/12 are the eyes.
 // Shared by the S3 mascot row and the M5StickC Plus status-panel mascot.
@@ -675,14 +709,14 @@ void uiBootProgress(int percent, const char* label) {
     halFlush();
 }
 
-void uiSetupScreen(const char* apName, const char* apPass) {
+void uiSetupScreen(const char* apName, const char* apPass, bool reconfigure) {
     halClear(C_BG);
 
     lcd.fillRect(0, 0, SCREEN_W, SY(18), C_ACCENT);
     lcd.setTextColor(C_TEXT, C_ACCENT);
     lcd.setTextSize(TS(1));
     lcd.setCursor(SX(6), SY(5));
-    lcd.print("SETUP MODE");
+    lcd.print(reconfigure ? "WIFI RECONNECT" : "SETUP MODE");
 
     lcd.setTextColor(C_DIM, C_BG);
     lcd.setTextSize(TS(1));
@@ -712,6 +746,13 @@ void uiSetupScreen(const char* apName, const char* apPass) {
     lcd.setTextSize(TS(2));
     lcd.setCursor(SX(10), SY(104));
     lcd.print("192.168.4.1");
+
+    if (reconfigure) {
+        lcd.setTextColor(C_DIM, C_BG);
+        lcd.setTextSize(TS(1));
+        lcd.setCursor(SX(10), SY(124));
+        lcd.print("Token, PIN & settings kept");
+    }
     halFlush();
 }
 
@@ -819,6 +860,16 @@ void uiPinScreen(int pos, const int digits[4]) {
     g.setTextColor(0x4A49, C_BG);
     g.setCursor((SCREEN_W - (int)strlen(note) * 6) / 2, boxY + boxH + 32);
     g.print(note);
+
+#ifdef BOARD_TDISPLAY_S3
+    // WiFi is already up on this board, so the device's LAN address is known
+    // while it sits locked.
+    if (s_netUrl[0]) {
+        g.setTextColor(C_CYAN, C_BG);
+        g.setCursor((SCREEN_W - (int)strlen(s_netUrl) * 6) / 2, boxY + boxH + 48);
+        g.print(s_netUrl);
+    }
+#endif
 #else
     g.print("[A] cycle digit");
     g.setCursor(SX(148), hintY);
@@ -864,10 +915,14 @@ void uiDashboard(const UsageData& data, unsigned long lastFetchMs, int rssi, int
 
     // Header
     g.fillRect(0, 0, SCREEN_W, SY(18), C_HEAD);
+#ifdef BOARD_TDISPLAY_S3
+    drawHeaderLeft(g);
+#else
     g.setTextColor(C_TEXT, C_HEAD);
     g.setTextSize(TS(1));
     g.setCursor(SX(4), SY(5));
     g.print("CLAUDE USAGE");
+#endif
 
     unsigned long ago = (millis() - lastFetchMs) / 1000;
 #ifdef MANGO_UI
@@ -957,6 +1012,11 @@ void uiDashboardClock(const UsageData& data, unsigned long lastFetchMs, int rssi
 
     // Header "rssi / ago": repaint the header band over its own colour.
     unsigned long ago = (millis() - lastFetchMs) / 1000;
+#ifdef BOARD_TDISPLAY_S3
+    // Ride the 10s tick to alternate the left text (device label ↔ panel URL).
+    s_hdrShowUrl = !s_hdrShowUrl;
+    drawHeaderLeft(g);
+#endif
     g.fillRect(SCREEN_W / 2, 0, SCREEN_W / 2, SY(18), C_HEAD);
     g.setTextColor(C_TEXT, C_HEAD);
     g.setTextSize(TS(1));
@@ -1010,7 +1070,7 @@ void uiError(const char* title, const char* detail) {
     halFlush();
 }
 
-void uiLockout(int attempts, int maxAttempts, int lockoutSec) {
+void uiLockoutStatic(int attempts, int maxAttempts, int lockoutSec) {
     halClear(C_BG);
     lcd.setTextColor(C_CRIT, C_BG);
     lcd.setTextSize(TS(2));
@@ -1023,16 +1083,15 @@ void uiLockout(int attempts, int maxAttempts, int lockoutSec) {
     lcd.printf("Attempt %d of %d", attempts, maxAttempts);
     lcd.setCursor(SX(10), SY(75));
     lcd.printf("Locked for %d seconds", lockoutSec);
+}
 
-    for (int s = lockoutSec; s > 0; s--) {
-        lcd.fillRect(SX(10), SY(95), SX(200), SY(20), C_BG);
-        lcd.setTextColor(C_WARN, C_BG);
-        lcd.setTextSize(TS(2));
-        lcd.setCursor(SX(10), SY(95));
-        lcd.printf("%ds", s);
-        halFlush();
-        delay(1000);
-    }
+void uiLockoutTick(int secondsLeft) {
+    lcd.fillRect(SX(10), SY(95), SX(200), SY(20), C_BG);
+    lcd.setTextColor(C_WARN, C_BG);
+    lcd.setTextSize(TS(2));
+    lcd.setCursor(SX(10), SY(95));
+    lcd.printf("%ds", secondsLeft);
+    halFlush();
 }
 
 #endif // BOARD_ESP32C3_OLED

--- a/src/ui.h
+++ b/src/ui.h
@@ -6,7 +6,7 @@
 
 void uiInit();
 void uiBootProgress(int percent, const char* label);
-void uiSetupScreen(const char* apName, const char* apPass);
+void uiSetupScreen(const char* apName, const char* apPass, bool reconfigure = false);
 void uiPinScreen(int pos, const int digits[4]);
 void uiConnecting(const char* ssid, int attempt = 0);
 void uiDashboard(const UsageData& data, unsigned long lastFetchMs, int rssi, int batPct);
@@ -14,12 +14,22 @@ void uiDashboard(const UsageData& data, unsigned long lastFetchMs, int rssi, int
 // so the periodic refresh doesn't flicker. Call when only time has passed, not data.
 void uiDashboardClock(const UsageData& data, unsigned long lastFetchMs, int rssi);
 void uiError(const char* title, const char* detail = nullptr);
-void uiLockout(int attempts, int maxAttempts, int lockoutSec);
+// Lockout is drawn in two parts so the caller owns the wait: Static paints the
+// chrome once, Tick repaints the remaining seconds. This lets the wait loop be
+// sliced (and, on the T-Display S3, pump the web panel between slices).
+void uiLockoutStatic(int attempts, int maxAttempts, int lockoutSec);
+void uiLockoutTick(int secondsLeft);
+#ifdef BOARD_TDISPLAY_S3
+// LAN URL shown on the PIN screen and alternated into the dashboard header.
+void uiSetNetInfo(const char* url);
+// Header label (from dev_name, uppercased); empty falls back to "CLAUDE USAGE".
+void uiSetHeaderLabel(const char* name);
+#endif
 #ifdef MANGO_UI
 // Latest model health for the dashboard's mascot row; cached until the next call.
 void uiSetModelStatus(const ModelStatus& s);
-// Flip the panel 180° (and clear it); caller redraws the current screen.
-void uiToggleRotation();
+// Apply (or undo) the 180° flip and clear; caller redraws the current screen.
+void uiApplyRotation(bool flipped);
 // Close (true) or open (false) the healthy mascots' eyes on the dashboard.
 void uiBlinkTick(bool closed);
 #endif // MANGO_UI


### PR DESCRIPTION
First of four PRs toward **v3.0.0 ✨ Dust** (T-Display S3 first).

- `tdisplay-s3` env moves to `default_16MB.csv` (app slot 1.25 MB → 6.25 MB; flash offsets and NVS location unchanged, so settings survive reflash) and enables the board's 8 MB OPI PSRAM
- New `settings` module owns all NVS access; `app_state.h` shares state with the upcoming web panel
- S3 boot order is now WiFi → NTP → TZ → PIN: the LAN address is known while locked, shown on the PIN screen and alternated into the dashboard header with the device name
- WiFi failure at boot falls back to a reconfigure portal (token, PIN and preferences kept) instead of the old infinite reboot loop
- Brightness and screen-flip changes now persist to NVS (all boards)
- Timezone plumbing (`tz_min` + POSIX TZ) ready for the clock/chart screens
- `FW_VERSION` is `3.0.0-dev` until the Dust release PR

Verified: all 8 envs build; flashed on hardware — boot order, PIN-screen URL, header alternation, persisted brightness/flip and A+B refresh all confirmed. The URL itself starts serving in the next PR (web panel).