### PR TITLE
feat(m5stick-cplus): Dust on tier S — v3.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ A standalone desk gadget that polls the Anthropic API and shows your Claude Code
 - **PIN-encrypted token** — AES-256-GCM on the device's own flash; the PIN is never stored, and 10 wrong tries wipes it
 - **Captive-portal setup** — no hardcoded credentials, no serial console; configure it from your phone
 
-**✨ New in Dust (v3 — [T-Display S3](https://github.com/oauramos/claude-usage-stick/wiki/LilyGo-T-Display-S3) first)**
+**✨ New in Dust (v3 — [T-Display S3](https://github.com/oauramos/claude-usage-stick/wiki/LilyGo-T-Display-S3) and [M5StickC Plus](https://github.com/oauramos/claude-usage-stick/wiki/M5StickC-Plus))**
 
 - **[Web control panel](https://github.com/oauramos/claude-usage-stick/wiki/Web-Panel)** — the stick serves its own settings page at `http://claude-usage-stick.local`: every setting, WiFi changes and factory reset from any browser on your LAN. Logging in with the PIN also unlocks the screen
 - **Token rotation without a reset** — paste a fresh `claude setup-token`, confirmed with your PIN and verified live against the API; the stored token is write-only

--- a/platformio.ini
+++ b/platformio.ini
@@ -4,9 +4,12 @@ board = m5stick-c
 framework = arduino
 monitor_speed = 115200
 upload_port = /dev/cu.usbserial-*
-upload_speed = 115200
+upload_speed = 1500000
 board_build.filesystem = spiffs
-board_build.partitions = default.csv
+; 4MB chip: the default 1.25MB app slot can't fit Dust. min_spiffs keeps the
+; dual-app layout (1.9MB each) and its 192KB data partition dwarfs the 684-byte
+; history file. Flash offsets and NVS (0x9000) are unchanged — settings survive.
+board_build.partitions = min_spiffs.csv
 
 lib_deps =
     m5stack/M5StickCPlus@^0.1.0
@@ -16,6 +19,7 @@ build_flags =
     -DARDUINO_M5STICK_C_PLUS
     -DBOARD_M5STICK_C_PLUS
     -DMANGO_UI
+    -DDUST_UI
     -DCORE_DEBUG_LEVEL=1
 
 [env:m5stick-cplus2]
@@ -108,6 +112,7 @@ lib_deps =
 build_flags =
     -DBOARD_TDISPLAY_S3
     -DMANGO_UI
+    -DDUST_UI
     -DBOARD_HAS_PSRAM
     -DARDUINO_USB_CDC_ON_BOOT=1
     -DUSER_SETUP_LOADED

--- a/src/config.h
+++ b/src/config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // ── Firmware version ─────────────────────────────────────
-#define FW_VERSION              "3.0.0"  // Dust — shown on the boot screen
+#define FW_VERSION              "3.1.0"  // Dust — shown on the boot screen
 
 // ── Polling ──────────────────────────────────────────────
 #define DEFAULT_POLL_SEC        120

--- a/src/history.cpp
+++ b/src/history.cpp
@@ -1,6 +1,6 @@
 #include "history.h"
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 
 #include <Arduino.h>
 #include <LittleFS.h>
@@ -148,4 +148,4 @@ void historySeedDemo(bool clear) {
 }
 #endif
 
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI

--- a/src/history.h
+++ b/src/history.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdint.h>
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 
 #include "api.h"
 
@@ -28,4 +28,4 @@ void historyErase();                         // wipe ring + file (factory reset)
 void historySeedDemo(bool clear);            // synthetic 7 days (or clear) for testing
 #endif
 
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,10 +4,11 @@
  *
  * PIN entry: A cycles the digit, B confirms
  * Dashboard (Clarity): A cycles brightness, B forces a refresh
- * Dashboard (Mango):   A flips the screen, B cycles brightness, A+B force refresh
+ * Screens (Dust):      A tap = next screen, A held = flip, B = brightness,
+ *                      A+B = force refresh
  * A+B held on boot: factory reset → wipe NVS → re-enter setup
  *
- * Boot order differs per board: the T-Display S3 brings WiFi up before the PIN
+ * Boot order differs per board: DUST_UI boards bring WiFi up before the PIN
  * (the LAN address is shown while locked, and a failed connect falls back to a
  * WiFi-reconfigure portal); every other board keeps the PIN-first order.
  *
@@ -54,7 +55,7 @@ static bool enterPin(char* pinOut, int maxLen) {
         uiPinScreen(pos, digits);
         while (true) {
             halUpdate();
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
             panelService();
             if (panelUnlockPending()) return false;
 #endif
@@ -119,7 +120,7 @@ static void refresh() {
     uiSetModelStatus(g_models);
 #endif
     g_lastFetchMs = millis();
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     screensOnData();   // records history + redraws whichever screen shows it
 #else
     uiDashboard(g_usage, g_lastFetchMs, WiFi.RSSI(), halBatPercent());
@@ -156,7 +157,7 @@ static void unlockPhase(int progressPct) {
         for (int s = lockSec; s > 0 && !webUnlocked; s--) {
             uiLockoutTick(s);
             for (int slice = 0; slice < 50; slice++) {
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
                 panelService();
                 if (panelUnlockPending()) { webUnlocked = true; break; }
 #endif
@@ -164,7 +165,7 @@ static void unlockPhase(int progressPct) {
             }
         }
     }
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     panelConsumeUnlock();
 #endif
     g_unlocked = true;
@@ -174,7 +175,7 @@ static void unlockPhase(int progressPct) {
     halBtnBWasPressed();
 }
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 // WiFi before the PIN on this board: the creds need no PIN, and the device's
 // LAN address is already known (and shown) while it sits locked. A dead network
 // lands in the reconfigure portal instead of the old infinite reboot loop.
@@ -272,7 +273,7 @@ void setup() {
     if (g_settings.flip) uiApplyRotation(true);
 #endif
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     netPhase();
     uiBootProgress(78, "Preparing storage...");
     historyInit();   // first boot formats the data partition (~1-3s)
@@ -291,7 +292,7 @@ void setup() {
 void loop() {
     halUpdate();
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     panelService();
     panelConsumeUnlock();   // post-boot logins don't need the boot-phase handoff
     uint8_t acts = panelTakeAction();
@@ -305,7 +306,7 @@ void loop() {
     if (acts & (PANEL_ACT_REDRAW | PANEL_ACT_FLIP)) screensOnSettings();
 #endif
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     // A short = next screen · A held ≥600ms = flip · B = brightness ·
     // A+B = force refresh. Latches keep each gesture firing exactly once;
     // every gesture pauses the carousel for 10s.
@@ -356,31 +357,6 @@ void loop() {
             }
         }
     }
-#elif defined(MANGO_UI)
-    // A flips the screen 180°, B cycles brightness, A+B together = force refresh
-    // (the Clarity Button-B action). A single press only commits after a short
-    // window so the other button can still join to form the combo.
-    static unsigned long aPressAt = 0, bPressAt = 0;
-    const unsigned long comboWindowMs = 350;
-    if (halBtnAWasPressed()) aPressAt = millis();
-    if (halBtnBWasPressed()) bPressAt = millis();
-
-    if ((aPressAt && (bPressAt || halBtnBIsPressed())) ||
-        (bPressAt && halBtnAIsPressed())) {
-        aPressAt = bPressAt = 0;
-        refresh();
-    } else if (aPressAt && millis() - aPressAt > comboWindowMs) {
-        aPressAt = 0;
-        g_settings.flip = !g_settings.flip;
-        uiApplyRotation(g_settings.flip);
-        settingsPutU8("flip", g_settings.flip);
-        uiDashboard(g_usage, g_lastFetchMs, WiFi.RSSI(), halBatPercent());
-    } else if (bPressAt && millis() - bPressAt > comboWindowMs) {
-        bPressAt = 0;
-        g_settings.brightness = (g_settings.brightness + 1) % 4;
-        halSetBrightness(g_settings.brightness);
-        settingsPutInt("brightness", g_settings.brightness);
-    }
 #else
     if (halBtnAWasPressed()) {
 #ifdef BOARD_ESP32C3_OLED
@@ -405,7 +381,7 @@ void loop() {
     // Healthy mascots blink every 2s (eyes shut for 150ms) to show liveness.
     static unsigned long lastBlink = 0;
     static bool eyesClosed = false;
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     // Blinking draws at mascot coordinates — only valid on the dashboard.
     bool blinkScreen = screensCurrent() == SCR_DASH;
     if (!blinkScreen) eyesClosed = false;   // a screen change redrew them open
@@ -422,7 +398,7 @@ void loop() {
     }
 #endif
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     screensTick();                        // carousel dwell + 10s header beat + clock minute
     if (newsTick()) screensOnNews();      // blocks 2-5s only when a fetch is due
 #else

--- a/src/news.cpp
+++ b/src/news.cpp
@@ -1,6 +1,6 @@
 #include "news.h"
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 
 #include <Arduino.h>
 #include <WiFiClientSecure.h>
@@ -229,4 +229,4 @@ bool newsTick() {
     return ok;
 }
 
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI

--- a/src/news.h
+++ b/src/news.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdint.h>
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 
 // Anthropic news, streamed from the RSS feed in config.h. The full feed is
 // ~200KB; the fetch reads only until the first NEWS_MAX_ITEMS items and
@@ -25,4 +25,4 @@ extern NewsState g_news;
 // caller can redraw the news screen. Blocks 2–5s while fetching.
 bool newsTick();
 
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI

--- a/src/panel.cpp
+++ b/src/panel.cpp
@@ -1,6 +1,6 @@
 #include "panel.h"
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 
 #include <Arduino.h>
 #include <WiFi.h>
@@ -574,4 +574,4 @@ uint8_t panelTakeAction() {
     return due;
 }
 
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI

--- a/src/panel.h
+++ b/src/panel.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdint.h>
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 
 // LAN control panel: HTTP on :80 in STA mode, login = the device PIN.
 // Single-threaded: handlers run inside panelService(), which is called from
@@ -22,4 +22,4 @@ bool    panelUnlockPending();               // a web login decrypted the token w
 void    panelConsumeUnlock();
 uint8_t panelTakeAction();                  // due actions; reboot/reset wait ~400ms so the response flushes
 
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI

--- a/src/screens.cpp
+++ b/src/screens.cpp
@@ -1,6 +1,6 @@
 #include "screens.h"
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 
 #include <Arduino.h>
 #include <WiFi.h>
@@ -135,4 +135,4 @@ void screensOnSettings() {
     screensShow(s_current);
 }
 
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI

--- a/src/screens.h
+++ b/src/screens.h
@@ -1,7 +1,7 @@
 #pragma once
 #include <stdint.h>
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 
 // Screen orchestration for the v3 carousel. Drawing lives in ui.cpp; this
 // module owns which screen is current, the dwell timer, and the redraw beats.
@@ -17,4 +17,4 @@ void   screensOnData();        // after a usage fetch: redraw what depends on it
 void   screensOnNews();        // news fetch finished
 void   screensOnSettings();    // mode/mask/dwell changed from the panel
 
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI

--- a/src/ui.cpp
+++ b/src/ui.cpp
@@ -318,7 +318,7 @@ void uiDashboardClock(const UsageData& data, unsigned long lastFetchMs, int rssi
   #define SY(n) (n)
 #endif
 
-#if defined(BOARD_CROWPANEL_ADV_35) || defined(BOARD_TDISPLAY_S3)
+#if defined(BOARD_CROWPANEL_ADV_35) || defined(DUST_UI)
 // The CrowPanel's ILI9488 is too slow to clear-then-redraw on screen without flicker,
 // and the T-Display S3's v3 screen carousel would flash on every transition.
 // The dashboard (and the S3's other screens) render into an off-screen sprite (PSRAM)
@@ -402,11 +402,16 @@ void uiApplyRotation(bool flipped) {
     halClear(C_BG);
 }
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 // The header's left text alternates between the device label and the panel URL
 // on the 10s clock tick. Both strings print opaque at a fixed width so each
-// phase fully covers the other without a fillRect (no flicker). 28 chars stops
-// short of the right cluster's worst-case extent (~x187).
+// phase fully covers the other without a fillRect (no flicker). The pad stops
+// short of the right cluster's worst-case extent (~x187 at 320px, ~x137 at 240px).
+#ifdef BOARD_TDISPLAY_S3
+  #define HDR_LEFT_FMT "%-28.28s"
+#else
+  #define HDR_LEFT_FMT "%-21.21s"
+#endif
 static char s_netUrl[40]      = "";
 static char s_hdrLabel[29]    = "CLAUDE USAGE";
 static bool s_hdrShowUrl      = false;
@@ -421,14 +426,18 @@ void uiSetHeaderLabel(const char* name) {
     for (char* p = s_hdrLabel; *p; p++) *p = toupper((unsigned char)*p);
 }
 
+// Which model mascots render (panel setting) — shared by both tiers.
+static uint8_t s_mdlMask = 0x0F;
+void uiSetModelMask(uint8_t mask) { s_mdlMask = mask & 0x0F ? mask & 0x0F : 0x0F; }
+
 template <class GFX>
 static void drawHeaderLeft(GFX& g) {
     g.setTextColor(C_TEXT, C_HEAD);
     g.setTextSize(1);
     g.setCursor(4, 5);
-    g.printf("%-28.28s", (s_hdrShowUrl && s_netUrl[0]) ? s_netUrl : s_hdrLabel);
+    g.printf(HDR_LEFT_FMT, (s_hdrShowUrl && s_netUrl[0]) ? s_netUrl : s_hdrLabel);
 }
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI
 
 // Clawd, 18x5 px (MSB = leftmost column). The row-1 gaps at cols 5/12 are the eyes.
 // Shared by the S3 mascot row and the M5StickC Plus status-panel mascot.
@@ -498,10 +507,6 @@ static void drawMascot(GFX& g, int x, int y, int W, int rh, uint16_t color, bool
 #define MASCOT_NAME_Y   156
 #define MASCOT_CX(i) (MASCOT_CX0 + (i) * MASCOT_SPACING)
 #define MASCOT_X(i)  (MASCOT_CX(i) - MASCOT_W / 2)
-
-// Which mascots render (panel setting) — the N enabled ones re-center evenly.
-static uint8_t s_mdlMask = 0x0F;
-void uiSetModelMask(uint8_t mask) { s_mdlMask = mask & 0x0F ? mask & 0x0F : 0x0F; }
 
 // Fills idx[] with the enabled model indices and cx[] with their centers;
 // returns N. Shared by the status panel and the blink tick so eyes always
@@ -599,7 +604,8 @@ void uiBlinkTick(bool closed) {
 #define PANEL_ROW0_Y    98
 #define PANEL_ROW1_Y    114
 
-static void drawModelsDivider(TFT_eSPI& g, int capY, int lineY) {
+template <class GFX>
+static void drawModelsDivider(GFX& g, int capY, int lineY) {
     const char* cap = "MODELS";
     int capW = (int)strlen(cap) * 6;
     int cx   = SCREEN_W / 2;
@@ -612,24 +618,30 @@ static void drawModelsDivider(TFT_eSPI& g, int capY, int lineY) {
                     (SCREEN_W - 14) - (cx + capW / 2 + 6), C_HEAD_DK);
 }
 
-static void drawStatusPanel(TFT_eSPI& g) {
+template <class GFX>
+static void drawStatusPanel(GFX& g) {
     static const char* names[4] = {"HAIKU", "SONNET", "OPUS", "FABLE"};
     bool up[4] = {s_modelStatus.haikuUp, s_modelStatus.sonnetUp,
                   s_modelStatus.opusUp,  s_modelStatus.fableUp};
     drawModelsDivider(g, PANEL_CAP_Y, PANEL_LINE_Y);
 
-    // One Clawd to the left of the grid reflects overall health: Claude orange when
-    // every model is up, gray with X-eyes if any is down, gray (no X) until fetched.
+    // One Clawd to the left of the grid reflects overall health of the models
+    // the user shows: Claude orange when every one is up, gray with X-eyes if
+    // any is down, gray (no X) until the status was fetched at least once.
     bool anyDown = false;
-    for (int i = 0; i < 4; i++) anyDown = anyDown || !up[i];
+    for (int i = 0; i < 4; i++)
+        if (s_mdlMask & (1 << i)) anyDown = anyDown || !up[i];
     bool dead = s_modelStatus.ok && anyDown;
     drawMascot(g, PANEL_MASCOT_X, PANEL_MASCOT_Y, 18 * PANEL_MASCOT_S, PANEL_MASCOT_S * 2,
                (!s_modelStatus.ok || dead) ? C_DIM : C_HEAD, dead);
 
+    // Grid packs the enabled models into consecutive slots.
     const int colX[2] = {PANEL_COL0_X, PANEL_COL1_X};
     const int rowY[2] = {PANEL_ROW0_Y, PANEL_ROW1_Y};
     g.setTextSize(1);
+    int k = 0;
     for (int i = 0; i < 4; i++) {
+        if (!(s_mdlMask & (1 << i))) continue;
         const char* st;
         uint16_t col;
         if (!s_modelStatus.ok) { st = "?";    col = C_DIM;  }   // status never fetched
@@ -638,31 +650,36 @@ static void drawStatusPanel(TFT_eSPI& g) {
         char buf[16];
         snprintf(buf, sizeof(buf), "%-6s %s", names[i], st);   // padded name aligns the status column
         g.setTextColor(col, C_BG);
-        g.setCursor(colX[i % 2], rowY[i / 2]);
+        g.setCursor(colX[k % 2], rowY[k / 2]);
         g.print(buf);
+        k++;
     }
 }
 
 // Blink the panel mascot's eyes — only when he's the healthy (orange) Clawd; the
-// gray "something's down"/unknown Clawd stays still. The 2s liveness blink.
+// gray "something's down"/unknown Clawd stays still. Eyes go into the retained
+// sprite and one push refreshes the panel (this tier is Dust-only now).
 void uiBlinkTick(bool closed) {
     bool up[4] = {s_modelStatus.haikuUp, s_modelStatus.sonnetUp,
                   s_modelStatus.opusUp,  s_modelStatus.fableUp};
     bool anyDown = false;
-    for (int i = 0; i < 4; i++) anyDown = anyDown || !up[i];
+    for (int i = 0; i < 4; i++)
+        if (s_mdlMask & (1 << i)) anyDown = anyDown || !up[i];
     if (!s_modelStatus.ok || anyDown) return;
 
+    auto& g = dashTarget();
     int ch = PANEL_MASCOT_S * 2;
     int ey = PANEL_MASCOT_Y + ch;   // eye row 1
     for (int e = 0; e < 2; e++) {
         int ex = PANEL_MASCOT_X + CLAWD_EYE_COLS[e] * PANEL_MASCOT_S;
         if (closed) {
-            lcd.fillRect(ex, ey, PANEL_MASCOT_S, ch, C_HEAD);           // lid down
-            lcd.fillRect(ex, ey + ch / 2 - 1, PANEL_MASCOT_S, 2, C_BG); // shut line
+            g.fillRect(ex, ey, PANEL_MASCOT_S, ch, C_HEAD);           // lid down
+            g.fillRect(ex, ey + ch / 2 - 1, PANEL_MASCOT_S, 2, C_BG); // shut line
         } else {
-            lcd.fillRect(ex, ey, PANEL_MASCOT_S, ch, C_BG);            // eye open
+            g.fillRect(ex, ey, PANEL_MASCOT_S, ch, C_BG);            // eye open
         }
     }
+    UI_PUSH_DASH();
 }
 #endif // BOARD_TDISPLAY_S3 four-mascot row vs M5StickC Plus status panel
 
@@ -705,10 +722,11 @@ static void drawHeaderRight(GFX& g, int rssi, unsigned long ago, int batPct) {
 }
 #endif // MANGO_UI
 
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 // ── v3 carousel screens (chart / news / clock) ──────────────────────────────
 // All render into the retained sprite and push whole — flicker-free by
-// construction, so no partial-update choreography is needed.
+// construction, so no partial-update choreography is needed. Geometry derives
+// from SCREEN_W/H where it can; the few tier-specific numbers sit inline.
 
 void uiHeaderAlternate() { s_hdrShowUrl = !s_hdrShowUrl; }
 
@@ -736,7 +754,7 @@ void uiChartScreen(const HistSlot* slots, uint32_t newestEpoch,
     g.setCursor(SCREEN_W - 10 - 2 * 6, 22);
     g.print("7D");
 
-    const int px0 = 10, px1 = 309, py0 = 34, py1 = 136;
+    const int px0 = 10, px1 = SCREEN_W - 11, py0 = 34, py1 = SCREEN_H - 34;
 
     bool any = false;
     for (int i = 0; i < HIST_SLOTS && !any; i++) any = slots[i].h5 != HIST_EMPTY;
@@ -832,8 +850,13 @@ void uiNewsScreen(const NewsState& news, unsigned long lastFetchMs, int rssi) {
     }
 
     // Three items: two wrapped title lines + a date line each
-    const int perLine = 50;   // (320-20)/6
-    int y = 36;
+    const int perLine = (SCREEN_W - 20) / 6;
+#ifdef BOARD_TDISPLAY_S3
+    const int itemY0 = 36, dateDy = 22, sepDy = 32, step = 38;
+#else
+    const int itemY0 = 32, dateDy = 20, sepDy = 29, step = 32;   // 240x135
+#endif
+    int y = itemY0;
     for (int i = 0; i < 3 && i < news.count; i++) {
         const NewsItem& it = news.items[i];
         const char* t = it.title;
@@ -841,7 +864,7 @@ void uiNewsScreen(const NewsState& news, unsigned long lastFetchMs, int rssi) {
         int split = len;
         if (len > perLine) {
             split = perLine;
-            while (split > 30 && t[split] != ' ') split--;   // wrap on a space
+            while (split > perLine / 2 && t[split] != ' ') split--;   // wrap on a space
             if (t[split] != ' ') split = perLine;
         }
         g.setTextColor(C_TEXT, C_BG);
@@ -853,10 +876,10 @@ void uiNewsScreen(const NewsState& news, unsigned long lastFetchMs, int rssi) {
             for (int c = 0; c < perLine && rest[c]; c++) g.print(rest[c]);
         }
         g.setTextColor(C_HEAD_DK, C_BG);
-        g.setCursor(10, y + 22);
+        g.setCursor(10, y + dateDy);
         g.print(it.date[0] ? it.date : "-");
-        if (i < 2) g.drawFastHLine(10, y + 32, SCREEN_W - 20, C_BAR_BG);
-        y += 38;
+        if (i < 2) g.drawFastHLine(10, y + sepDy, SCREEN_W - 20, C_BAR_BG);
+        y += step;
     }
     UI_PUSH_DASH();
 }
@@ -881,40 +904,45 @@ void uiClockScreen(const UsageData& data, unsigned long lastFetchMs, int rssi) {
         strlcpy(dateLine, "no time sync", sizeof(dateLine));
     }
 
+#ifdef BOARD_TDISPLAY_S3
+    const int tSz = 5, tY = 44, dY = 96, barY = 140, barW = 84, bar1X = 14, bar2X = 170;
+#else
+    const int tSz = 4, tY = 38, dY = 82, barY = 116, barW = 56, bar1X = 8, bar2X = 124;
+#endif
     g.setTextColor(C_TEXT, C_BG);
-    g.setTextSize(5);   // 5 glyphs x 30px = 150px wide, 40px tall
-    g.setCursor((SCREEN_W - 5 * 30) / 2 + 2, 44);
+    g.setTextSize(tSz);   // 5 glyphs of 6*tSz px
+    g.setCursor((SCREEN_W - 5 * 6 * tSz) / 2 + 2, tY);
     g.print(hhmm);
 
     g.setTextSize(2);
     g.setTextColor(C_DIM, C_BG);
-    g.setCursor((SCREEN_W - (int)strlen(dateLine) * 12) / 2, 96);
+    g.setCursor((SCREEN_W - (int)strlen(dateLine) * 12) / 2, dY);
     g.print(dateLine);
 
     // Micro usage bars along the bottom
     auto microBar = [&](int x, const char* label, float pct) {
         g.setTextSize(1);
         g.setTextColor(C_DIM, C_BG);
-        g.setCursor(x, 140);
+        g.setCursor(x, barY);
         g.print(label);
-        int bx = x + 18, bw = 84;
-        g.fillRect(bx, 140, bw, 8, C_BAR_BG);
+        int bx = x + 18, bw = barW;
+        g.fillRect(bx, barY, bw, 8, C_BAR_BG);
         char ps[8] = "--%";
         if (data.ok) {
             int fw = constrain((int)(bw * pct / 100.0f), 0, bw);
-            if (fw > 0) g.fillRect(bx, 140, fw, 8, C_HEAD);
+            if (fw > 0) g.fillRect(bx, barY, fw, 8, C_HEAD);
             snprintf(ps, sizeof(ps), "%.0f%%", pct);
         }
         g.setTextColor(C_TEXT, C_BG);
-        g.setCursor(bx + bw + 6, 140);
+        g.setCursor(bx + bw + 6, barY);
         g.print(ps);
     };
-    microBar(14, "5H", data.h5);
-    microBar(170, "7D", data.d7);
+    microBar(bar1X, "5H", data.h5);
+    microBar(bar2X, "7D", data.d7);
 
     UI_PUSH_DASH();
 }
-#endif // BOARD_TDISPLAY_S3
+#endif // DUST_UI carousel screens
 
 void uiInit() {
     lcd.setRotation(SCREEN_ROT);
@@ -1099,22 +1127,23 @@ void uiPinScreen(int pos, const int digits[4]) {
     g.setCursor((SCREEN_W - (int)strlen(hint) * 6) / 2, hintY);
     g.print(hint);
 
-    static const char* note = "Hold A+B on boot = factory reset";
-    g.setTextColor(0x4A49, C_BG);
-    g.setCursor((SCREEN_W - (int)strlen(note) * 6) / 2, boxY + boxH + 32);
-    g.print(note);
-
-#ifdef BOARD_TDISPLAY_S3
-    // WiFi and the panel are already up on this board — the PIN can be entered
-    // from a browser on the LAN instead of cycling digits on the buttons.
+#ifdef DUST_UI
+    // WiFi and the panel are already up on Dust boards — the PIN can be
+    // entered from a browser on the LAN instead of cycling digits on buttons.
+    // Rows at +12/+27/+42 fit both the 320x170 and the 240x135 panel.
     if (s_netUrl[0]) {
         char unlockLine[52];
         snprintf(unlockLine, sizeof(unlockLine), "unlock: %s", s_netUrl);
         g.setTextColor(C_CYAN, C_BG);
-        g.setCursor((SCREEN_W - (int)strlen(unlockLine) * 6) / 2, boxY + boxH + 48);
+        g.setCursor((SCREEN_W - (int)strlen(unlockLine) * 6) / 2, boxY + boxH + 27);
         g.print(unlockLine);
     }
 #endif
+
+    static const char* note = "Hold A+B on boot = factory reset";
+    g.setTextColor(0x4A49, C_BG);
+    g.setCursor((SCREEN_W - (int)strlen(note) * 6) / 2, boxY + boxH + 42);
+    g.print(note);
 #else
     g.print("[A] cycle digit");
     g.setCursor(SX(148), hintY);
@@ -1150,7 +1179,7 @@ void uiConnecting(const char* ssid, int attempt) {
 }
 
 void uiDashboard(const UsageData& data, unsigned long lastFetchMs, int rssi, int batPct) {
-#if defined(BOARD_CROWPANEL_ADV_35) || defined(BOARD_TDISPLAY_S3)
+#if defined(BOARD_CROWPANEL_ADV_35) || defined(DUST_UI)
     auto& g = dashTarget();
     g.fillSprite(C_BG);
 #else
@@ -1160,7 +1189,7 @@ void uiDashboard(const UsageData& data, unsigned long lastFetchMs, int rssi, int
 
     // Header
     g.fillRect(0, 0, SCREEN_W, SY(18), C_HEAD);
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     drawHeaderLeft(g);
 #else
     g.setTextColor(C_TEXT, C_HEAD);
@@ -1249,7 +1278,7 @@ void uiDashboard(const UsageData& data, unsigned long lastFetchMs, int rssi, int
 
 void uiDashboardClock(const UsageData& data, unsigned long lastFetchMs, int rssi) {
     if (!data.ok) return;   // error layout is owned by the full uiDashboard
-#if defined(BOARD_CROWPANEL_ADV_35) || defined(BOARD_TDISPLAY_S3)
+#if defined(BOARD_CROWPANEL_ADV_35) || defined(DUST_UI)
     auto& g = dashTarget();   // update the retained sprite, then push it once
 #else
     auto& g = lcd;
@@ -1257,7 +1286,7 @@ void uiDashboardClock(const UsageData& data, unsigned long lastFetchMs, int rssi
 
     // Header "rssi / ago": repaint the header band over its own colour.
     unsigned long ago = (millis() - lastFetchMs) / 1000;
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
     // Repaint the left text with the current phase — screensTick() owns the
     // label ↔ URL alternation via uiHeaderAlternate().
     drawHeaderLeft(g);

--- a/src/ui.h
+++ b/src/ui.h
@@ -21,7 +21,7 @@ void uiError(const char* title, const char* detail = nullptr);
 // sliced (and, on the T-Display S3, pump the web panel between slices).
 void uiLockoutStatic(int attempts, int maxAttempts, int lockoutSec);
 void uiLockoutTick(int secondsLeft);
-#ifdef BOARD_TDISPLAY_S3
+#ifdef DUST_UI
 // LAN URL shown on the PIN screen and alternated into the dashboard header.
 void uiSetNetInfo(const char* url);
 // Header label (from dev_name, uppercased); empty falls back to "CLAUDE USAGE".

--- a/web/index.html
+++ b/web/index.html
@@ -897,7 +897,7 @@
     </span></span>
     <h4>M5StickC Plus</h4>
     <p class="board-meta">ESP32-PICO &middot; 1.14&Prime; 240&times;135</p>
-    <span class="board-tags"><span class="tag mango">&#129389; Mango &middot; tier S</span><span class="tag chipfam">ESP32</span></span>
+    <span class="board-tags"><span class="tag mango">&#10024; Dust &middot; tier S</span><span class="tag chipfam">ESP32</span></span>
   </label>
   <span class="sel-dot"></span>
 </div>

--- a/web/manifests/m5stick-cplus.json
+++ b/web/manifests/m5stick-cplus.json
@@ -1,6 +1,6 @@
 {
   "name": "Claude Usage Stick \u2014 M5StickC Plus",
-  "version": "2.0.0",
+  "version": "3.1.0",
   "new_install_prompt_erase": true,
   "builds": [
     {

--- a/web/manifests/tdisplay-s3.json
+++ b/web/manifests/tdisplay-s3.json
@@ -1,6 +1,6 @@
 {
   "name": "Claude Usage Stick \u2014 LilyGo T-Display S3",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "new_install_prompt_erase": true,
   "builds": [
     {

--- a/web/src/build.py
+++ b/web/src/build.py
@@ -102,9 +102,9 @@ BOARDS3D = {
 
 BOARDS = [
     # env, name, mcu, display, firmware tag (label, is_mango), chip family, fw version
-    ("m5stick-cplus", "M5StickC Plus", "ESP32-PICO", '1.14&Prime; 240&times;135', ("&#129389; Mango &middot; tier S", True), "ESP32", "2.0.0"),
+    ("m5stick-cplus", "M5StickC Plus", "ESP32-PICO", '1.14&Prime; 240&times;135', ("&#10024; Dust &middot; tier S", True), "ESP32", "3.1.0"),
     ("m5stick-cplus2", "M5StickC Plus2", "ESP32-PICO-V3", '1.14&Prime; 240&times;135', ("Clarity v1", False), "ESP32", "1.0.0"),
-    ("tdisplay-s3", "LilyGo T-Display S3", "ESP32-S3", '1.9&Prime; 320&times;170', ("&#10024; Dust &middot; tier L", True), "ESP32-S3", "3.0.0"),
+    ("tdisplay-s3", "LilyGo T-Display S3", "ESP32-S3", '1.9&Prime; 320&times;170', ("&#10024; Dust &middot; tier L", True), "ESP32-S3", "3.1.0"),
     ("t8-s2", "LilyGo T8 ESP32-S2", "ESP32-S2", '1.14&Prime; 135&times;240', ("Clarity v1", False), "ESP32-S2", "1.0.0"),
     ("crowpanel-adv-35", "CrowPanel Advance 3.5&Prime;", "ESP32-S3", '3.5&Prime; 480&times;320 touch', ("Clarity v1", False), "ESP32-S3", "1.0.0"),
     ("tdisplay-s3-amoled", "T-Display S3 AMOLED", "ESP32-S3", '1.91&Prime; 240&times;536', ("Clarity v1", False), "ESP32-S3", "1.0.0"),

--- a/wiki/LilyGo-T-Display-S3.md
+++ b/wiki/LilyGo-T-Display-S3.md
@@ -10,7 +10,7 @@ Part of [Claude Usage Stick](Home). The biggest small-format screen in the lineu
 | Display | 1.9" ST7789 LCD, 320×170, 8-bit parallel |
 | Battery | External via JST connector (not included) |
 | Buttons | Button A (BOOT, GPIO 0) · Button B (KEY, GPIO 14) |
-| Firmware | ✨ **Dust (v3.0.0)** — display tier **L** (reference board) |
+| Firmware | ✨ **Dust (v3.1.0)** — display tier **L** (reference board) |
 | PlatformIO env | `tdisplay-s3` |
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
 

--- a/wiki/M5StickC-Plus.md
+++ b/wiki/M5StickC-Plus.md
@@ -10,7 +10,7 @@ Part of [Claude Usage Stick](Home). The original board this project was built fo
 | Display | 1.14" ST7789 LCD, 240×135 |
 | Battery | 120 mAh internal |
 | Buttons | Button A (front, GPIO 37) · Button B (side, GPIO 39) |
-| Firmware | 🥭 **Mango (v2)** — display tier **S** (reference board) |
+| Firmware | ✨ **Dust (v3.1.0)** — display tier **S** (reference board) |
 | PlatformIO env | `m5stick-cplus` |
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c3w3hHWl) |
 
@@ -26,18 +26,23 @@ pio run -e m5stick-cplus -t upload     # firmware
 
 ## Controls
 
-| Context | Button A | Button B |
-| ------- | -------- | -------- |
-| PIN entry | Cycle the current digit (0–9) | Confirm digit, move to the next |
-| Dashboard | Flip screen 180° | Cycle brightness |
-| On boot | Hold **A+B** = factory reset (wipes all stored data) | |
+| Context | Gesture | Action |
+| ------- | ------- | ------ |
+| PIN entry | A tap / B tap | Cycle the current digit / confirm it — or unlock from a [browser](Web-Panel) instead |
+| Screens | A tap (front button) | Next screen (dashboard → chart → news → clock) |
+| Screens | A held ≥ 0.6 s | Flip screen 180° (saved) |
+| Screens | B tap (side) | Cycle brightness (saved) |
+| Screens | A+B together | Force refresh |
+| On boot | Hold **A+B** | Factory reset (wipes all stored data) |
 
-Refresh happens automatically on the poll interval — Mango has no manual-refresh button.
+Refresh happens automatically on the poll interval. Everything else — display mode, timezone, refresh interval, token rotation, WiFi — lives in the **[web panel](Web-Panel)**.
 
 ## Notes
 
-- As the **tier S** reference board, the dashboard's MODELS section shows one overall-health Clawd mascot plus a 2×2 `NAME UP/DOWN` text grid — see [Display tiers](The-UI#display-tiers).
-- During setup, the WiFi AP password is shown on the device screen.
+- As the **tier S** reference board, the dashboard's MODELS section shows one overall-health Clawd mascot plus a 2×2 `NAME UP/DOWN` text grid — see [Display tiers](The-UI#display-tiers). The [Dust screens](The-UI#what-dust-adds) (7-day chart, news, clock) are laid out for the 240×135 panel.
+- Dust on this board uses the `min_spiffs` partition table: the app slot grows to 1.9 MB inside the 4 MB flash, and the 192 KB data partition stores the 7-day history. Updating from v2 keeps your settings.
+- No PSRAM here — the flicker-free render buffer lives in internal RAM (~65 KB), which the ESP32 has room for.
+- During setup, the WiFi AP password is shown on the device screen. An unreachable WiFi at boot opens a **recovery AP** (token, PIN and settings kept).
 
 ---
 

--- a/wiki/Supported-Boards.md
+++ b/wiki/Supported-Boards.md
@@ -4,9 +4,9 @@ Eight boards run the firmware today. Each has its own guide with pinouts, contro
 
 | Board | MCU | Display | Firmware | PlatformIO env | Buy |
 | ----- | --- | ------- | -------- | -------------- | --- |
-| [M5StickC Plus](M5StickC-Plus) | ESP32-PICO | 1.14" 240×135 LCD | 🥭 **Mango (v2)** · tier S | `m5stick-cplus` | [AliExpress](https://s.click.aliexpress.com/e/_c3w3hHWl) |
+| [M5StickC Plus](M5StickC-Plus) | ESP32-PICO | 1.14" 240×135 LCD | ✨ **Dust (v3.1.0)** · tier S | `m5stick-cplus` | [AliExpress](https://s.click.aliexpress.com/e/_c3w3hHWl) |
 | [M5StickC Plus2](M5StickC-Plus2) | ESP32-PICO-V3-02 | 1.14" 240×135 LCD | Clarity (v1) | `m5stick-cplus2` | [AliExpress](https://s.click.aliexpress.com/e/_c3jkKlNj) |
-| [LilyGo T-Display S3](LilyGo-T-Display-S3) | ESP32-S3 | 1.9" 320×170 LCD | ✨ **Dust (v3.0.0)** · tier L | `tdisplay-s3` | [AliExpress](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
+| [LilyGo T-Display S3](LilyGo-T-Display-S3) | ESP32-S3 | 1.9" 320×170 LCD | ✨ **Dust (v3.1.0)** · tier L | `tdisplay-s3` | [AliExpress](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
 | [LilyGo T8 ESP32-S2](LilyGo-T8-ESP32-S2) | ESP32-S2 | 1.14" 135×240 LCD | Clarity (v1) | `t8-s2` | [AliExpress](https://s.click.aliexpress.com/e/_c2w1HnpJ) |
 | [Elecrow CrowPanel Advance 3.5"](CrowPanel-Advance-35) | ESP32-S3 | 3.5" 480×320 IPS touch | Clarity (v1) | `crowpanel-adv-35` | [AliExpress](https://s.click.aliexpress.com/e/_c4lDErmN) |
 | [LilyGo T-Display S3 AMOLED 1.91"](LilyGo-T-Display-S3-AMOLED) | ESP32-S3 | 1.91" 240×536 AMOLED | Clarity (v1) | `tdisplay-s3-amoled` | [AliExpress](https://s.click.aliexpress.com/e/_c3XNB9Hx) |
@@ -19,7 +19,7 @@ Plus any USB-C cable for flashing and power. Note that some cheap cables are **c
 ## Which one should I buy?
 
 - **Best overall:** [LilyGo T-Display S3](LilyGo-T-Display-S3) — the biggest small-format screen, two buttons, and the reference board for [tier L](The-UI#display-tiers) and the first to run ✨ Dust (web panel, screen carousel, 7-day chart).
-- **Smallest complete package:** [M5StickC Plus](M5StickC-Plus) — case, battery, and buttons included, zero soldering, and it runs Mango tier S.
+- **Smallest complete package:** [M5StickC Plus](M5StickC-Plus) — case, battery, and buttons included, zero soldering, and it runs ✨ Dust tier S.
 - **Cheapest:** [ESP32-C3-OLED](ESP32-C3-OLED) — but you wire your own buttons, and the 0.42" OLED shows a stripped-down layout.
 - **Biggest screen:** [CrowPanel Advance 3.5"](CrowPanel-Advance-35) — touch instead of buttons; still on the Clarity dashboard.
 

--- a/wiki/The-UI.md
+++ b/wiki/The-UI.md
@@ -10,7 +10,7 @@ Firmware releases carry names. Which one your board runs is listed in [Supported
 | v2 | 🥭 **Mango** | Everything in Clarity, plus model-status mascots, header icons, inline countdowns, and screen flip |
 | v3 | ✨ **Dust** | Everything in Mango, plus the [web panel](Web-Panel), screen modes (carousel · 7-day chart · Anthropic news · desk clock), timezone, mDNS, WiFi recovery, and token rotation without a reset |
 
-Boards still on **Clarity** keep the original minimal dashboard until they're migrated to their tier. **Dust** ships on the [T-Display S3](LilyGo-T-Display-S3) first.
+Boards still on **Clarity** keep the original minimal dashboard until they're migrated to their tier. **Dust** runs on the [T-Display S3](LilyGo-T-Display-S3) and the [M5StickC Plus](M5StickC-Plus); the rest follow as they migrate.
 
 ## Display tiers
 
@@ -33,7 +33,7 @@ The Mango dashboard keeps the same header and usage bars on every board, and ada
 
 ## What Dust adds
 
-*T-Display S3 first; other boards follow as they migrate.*
+*On the T-Display S3 (tier L) and M5StickC Plus (tier S); other boards follow as they migrate.*
 
 - **Four screens** — the Mango dashboard, a **7-day usage chart** (one sample per 30 min, gaps where the device was off, day markers at local midnight), **Anthropic news** headlines, and a **desk clock** (local time + micro usage bars)
 - **Three modes** — *Static* (dashboard only), *Carousel* (auto-rotates the screens you pick, 5–30 s dwell, pauses when you press a button), *Clock*. Button A steps through every screen manually in any mode

--- a/wiki/Web-Panel.md
+++ b/wiki/Web-Panel.md
@@ -1,6 +1,6 @@
 # Web panel
 
-*✨ Dust (v3) on the [LilyGo T-Display S3](LilyGo-T-Display-S3). Other boards will get it as they migrate to v3.*
+*✨ Dust (v3) on the [LilyGo T-Display S3](LilyGo-T-Display-S3) and [M5StickC Plus](M5StickC-Plus). Other boards will get it as they migrate to v3.*
 
 Once the device is on your WiFi, it serves its own control panel to any browser on the same network. Everything you'd want to change after setup lives there — no re-flash, no factory reset, no serial console.
 


### PR DESCRIPTION
✨ **Dust reaches its second board** — the M5StickC Plus (tier S reference, the project's original board).

**The two constraints the S3 didn't have, solved:**
- **4 MB flash**: `min_spiffs.csv` grows the app slot to 1.9 MB (Dust needs ~1.2 MB) and its 192 KB data partition dwarfs the 684-byte history file. Flash offsets and NVS stay put — updating from v2 keeps settings.
- **No PSRAM**: the flicker-free render sprite (240×135 ≈ 65 KB) allocates from internal RAM.

**Architecture**: a new `DUST_UI` feature flag replaces the `BOARD_TDISPLAY_S3` gates across panel/screens/history/news/boot/buttons — adding the next board to Dust is now one build flag plus tier geometry. Tier-S adaptations: chart plot derived from `SCREEN_W/H`, tighter news rows, size-4 clock digits, narrower micro bars, header pad and PIN-screen rows sized for 240×135; the tier-S status panel honors the mascot mask.

`FW_VERSION` → **3.1.0** (both Dust boards; flasher cards updated). Wiki: M5StickC-Plus page rewritten for Dust; Supported-Boards/The-UI/Web-Panel/README mention both boards.

**Verified**: all 8 envs build; flashed on the real Plus — v2 settings survived (it came up on WiFi with its dev_name-slug mDNS hostname), WiFi-first boot, panel serving gzip/401/404. Visual tier-S validation on hardware in progress.