### PR TITLE
fix: v3.0.1 — board additions are patch releases

### DIFF
--- a/src/config.h
+++ b/src/config.h
@@ -1,7 +1,7 @@
 #pragma once
 
 // ── Firmware version ─────────────────────────────────────
-#define FW_VERSION              "3.1.0"  // Dust — shown on the boot screen
+#define FW_VERSION              "3.0.1"  // Dust — shown on the boot screen
 
 // ── Polling ──────────────────────────────────────────────
 #define DEFAULT_POLL_SEC        120

--- a/web/index.html
+++ b/web/index.html
@@ -705,7 +705,7 @@
       </span></span></span></span>
       <span class="b3d-glow"></span>
     </div>
-      <p class="hero-3d-cap">LilyGo T-Display S3 &middot; &#10024; Dust v3.0.0 &middot; tier L &mdash; drag to spin</p>
+      <p class="hero-3d-cap">LilyGo T-Display S3 &middot; &#10024; Dust &middot; tier L &mdash; drag to spin</p>
     </div>
   </div>
 
@@ -822,7 +822,7 @@
                 aria-label="The web panel in a browser: usage bars at 62 and 31 percent with the four mascots, a 7-day history chart, display settings and a write-only token field">
           <div class="b-bar" aria-hidden="true"><i></i><i></i><i></i><span class="b-url">claude-usage-stick.local</span></div>
           <div class="b-page" aria-hidden="true">
-            <div class="p-head"><b>CLAUDE USAGE STICK</b><span>v3.0.0 &middot; Dust</span></div>
+            <div class="p-head"><b>CLAUDE USAGE STICK</b><span>&#10024; Dust</span></div>
             <div class="p-card">
               <div class="p-cap">Usage</div>
               <div class="p-win"><i class="fill" style="width:62%"></i><span>5-HOUR</span><span>62%</span></div>

--- a/web/manifests/m5stick-cplus.json
+++ b/web/manifests/m5stick-cplus.json
@@ -1,6 +1,6 @@
 {
   "name": "Claude Usage Stick \u2014 M5StickC Plus",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "new_install_prompt_erase": true,
   "builds": [
     {

--- a/web/manifests/tdisplay-s3.json
+++ b/web/manifests/tdisplay-s3.json
@@ -1,6 +1,6 @@
 {
   "name": "Claude Usage Stick \u2014 LilyGo T-Display S3",
-  "version": "3.1.0",
+  "version": "3.0.1",
   "new_install_prompt_erase": true,
   "builds": [
     {

--- a/web/src/build.py
+++ b/web/src/build.py
@@ -102,9 +102,9 @@ BOARDS3D = {
 
 BOARDS = [
     # env, name, mcu, display, firmware tag (label, is_mango), chip family, fw version
-    ("m5stick-cplus", "M5StickC Plus", "ESP32-PICO", '1.14&Prime; 240&times;135', ("&#10024; Dust &middot; tier S", True), "ESP32", "3.1.0"),
+    ("m5stick-cplus", "M5StickC Plus", "ESP32-PICO", '1.14&Prime; 240&times;135', ("&#10024; Dust &middot; tier S", True), "ESP32", "3.0.1"),
     ("m5stick-cplus2", "M5StickC Plus2", "ESP32-PICO-V3", '1.14&Prime; 240&times;135', ("Clarity v1", False), "ESP32", "1.0.0"),
-    ("tdisplay-s3", "LilyGo T-Display S3", "ESP32-S3", '1.9&Prime; 320&times;170', ("&#10024; Dust &middot; tier L", True), "ESP32-S3", "3.1.0"),
+    ("tdisplay-s3", "LilyGo T-Display S3", "ESP32-S3", '1.9&Prime; 320&times;170', ("&#10024; Dust &middot; tier L", True), "ESP32-S3", "3.0.1"),
     ("t8-s2", "LilyGo T8 ESP32-S2", "ESP32-S2", '1.14&Prime; 135&times;240', ("Clarity v1", False), "ESP32-S2", "1.0.0"),
     ("crowpanel-adv-35", "CrowPanel Advance 3.5&Prime;", "ESP32-S3", '3.5&Prime; 480&times;320 touch', ("Clarity v1", False), "ESP32-S3", "1.0.0"),
     ("tdisplay-s3-amoled", "T-Display S3 AMOLED", "ESP32-S3", '1.91&Prime; 240&times;536', ("Clarity v1", False), "ESP32-S3", "1.0.0"),

--- a/web/src/template.html
+++ b/web/src/template.html
@@ -680,7 +680,7 @@
     </div>
     <div class="hero-3d">
       <!-- HERO_3D -->
-      <p class="hero-3d-cap">LilyGo T-Display S3 &middot; &#10024; Dust v3.0.0 &middot; tier L &mdash; drag to spin</p>
+      <p class="hero-3d-cap">LilyGo T-Display S3 &middot; &#10024; Dust &middot; tier L &mdash; drag to spin</p>
     </div>
   </div>
 
@@ -797,7 +797,7 @@
                 aria-label="The web panel in a browser: usage bars at 62 and 31 percent with the four mascots, a 7-day history chart, display settings and a write-only token field">
           <div class="b-bar" aria-hidden="true"><i></i><i></i><i></i><span class="b-url">claude-usage-stick.local</span></div>
           <div class="b-page" aria-hidden="true">
-            <div class="p-head"><b>CLAUDE USAGE STICK</b><span>v3.0.0 &middot; Dust</span></div>
+            <div class="p-head"><b>CLAUDE USAGE STICK</b><span>&#10024; Dust</span></div>
             <div class="p-card">
               <div class="p-cap">Usage</div>
               <div class="p-win"><i class="fill" style="width:62%"></i><span>5-HOUR</span><span>62%</span></div>

--- a/wiki/LilyGo-T-Display-S3.md
+++ b/wiki/LilyGo-T-Display-S3.md
@@ -10,7 +10,7 @@ Part of [Claude Usage Stick](Home). The biggest small-format screen in the lineu
 | Display | 1.9" ST7789 LCD, 320×170, 8-bit parallel |
 | Battery | External via JST connector (not included) |
 | Buttons | Button A (BOOT, GPIO 0) · Button B (KEY, GPIO 14) |
-| Firmware | ✨ **Dust (v3.1.0)** — display tier **L** (reference board) |
+| Firmware | ✨ **Dust (v3.0.1)** — display tier **L** (reference board) |
 | PlatformIO env | `tdisplay-s3` |
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
 

--- a/wiki/M5StickC-Plus.md
+++ b/wiki/M5StickC-Plus.md
@@ -10,7 +10,7 @@ Part of [Claude Usage Stick](Home). The original board this project was built fo
 | Display | 1.14" ST7789 LCD, 240×135 |
 | Battery | 120 mAh internal |
 | Buttons | Button A (front, GPIO 37) · Button B (side, GPIO 39) |
-| Firmware | ✨ **Dust (v3.1.0)** — display tier **S** (reference board) |
+| Firmware | ✨ **Dust (v3.0.1)** — display tier **S** (reference board) |
 | PlatformIO env | `m5stick-cplus` |
 | Buy | [aliexpress.com](https://s.click.aliexpress.com/e/_c3w3hHWl) |
 

--- a/wiki/Supported-Boards.md
+++ b/wiki/Supported-Boards.md
@@ -4,9 +4,9 @@ Eight boards run the firmware today. Each has its own guide with pinouts, contro
 
 | Board | MCU | Display | Firmware | PlatformIO env | Buy |
 | ----- | --- | ------- | -------- | -------------- | --- |
-| [M5StickC Plus](M5StickC-Plus) | ESP32-PICO | 1.14" 240×135 LCD | ✨ **Dust (v3.1.0)** · tier S | `m5stick-cplus` | [AliExpress](https://s.click.aliexpress.com/e/_c3w3hHWl) |
+| [M5StickC Plus](M5StickC-Plus) | ESP32-PICO | 1.14" 240×135 LCD | ✨ **Dust (v3.0.1)** · tier S | `m5stick-cplus` | [AliExpress](https://s.click.aliexpress.com/e/_c3w3hHWl) |
 | [M5StickC Plus2](M5StickC-Plus2) | ESP32-PICO-V3-02 | 1.14" 240×135 LCD | Clarity (v1) | `m5stick-cplus2` | [AliExpress](https://s.click.aliexpress.com/e/_c3jkKlNj) |
-| [LilyGo T-Display S3](LilyGo-T-Display-S3) | ESP32-S3 | 1.9" 320×170 LCD | ✨ **Dust (v3.1.0)** · tier L | `tdisplay-s3` | [AliExpress](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
+| [LilyGo T-Display S3](LilyGo-T-Display-S3) | ESP32-S3 | 1.9" 320×170 LCD | ✨ **Dust (v3.0.1)** · tier L | `tdisplay-s3` | [AliExpress](https://s.click.aliexpress.com/e/_c4rvB1Mv) |
 | [LilyGo T8 ESP32-S2](LilyGo-T8-ESP32-S2) | ESP32-S2 | 1.14" 135×240 LCD | Clarity (v1) | `t8-s2` | [AliExpress](https://s.click.aliexpress.com/e/_c2w1HnpJ) |
 | [Elecrow CrowPanel Advance 3.5"](CrowPanel-Advance-35) | ESP32-S3 | 3.5" 480×320 IPS touch | Clarity (v1) | `crowpanel-adv-35` | [AliExpress](https://s.click.aliexpress.com/e/_c4lDErmN) |
 | [LilyGo T-Display S3 AMOLED 1.91"](LilyGo-T-Display-S3-AMOLED) | ESP32-S3 | 1.91" 240×536 AMOLED | Clarity (v1) | `tdisplay-s3-amoled` | [AliExpress](https://s.click.aliexpress.com/e/_c3XNB9Hx) |


### PR DESCRIPTION
Versioning correction: in this project's scheme, adding Dust support for another board is a **patch**, not a minor — so the M5StickC Plus release is **v3.0.1**, not 3.1.0. Updated in `config.h`, the flasher manifests and the wiki.

Bonus rot-proofing: the site's hero caption and the panel mock no longer embed a specific patch number (both were still stuck on `v3.0.0`); they now just say ✨ Dust. The tag `v3.1.0` will be deleted and `v3.0.1` created on this merge.