### PR TITLE
docs: Firefox flashes too; calmer flash CTA

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,9 +11,9 @@
 
 <a href="https://oauramos.github.io/claude-usage-stick/"><img src="assets/hero.gif" width="820" alt="Claude Usage Stick — a LilyGo T-Display S3 turning slowly, its screen showing the 5-hour and 7-day usage bars, reset countdowns and the four model mascots"/></a>
 
-## [ ⚡ >>>> Flash your ESP32 here! <<<< ⚡ ](https://oauramos.github.io/claude-usage-stick/)
+## [⚡ Flash your ESP32 — right from your browser](https://oauramos.github.io/claude-usage-stick/)
 
-*No toolchain, no drivers, no clone — just Chrome or Edge and a USB-C cable.*
+*No toolchain, no drivers, no clone — just Chrome, Edge or Firefox and a USB-C cable.*
 
 *5-hour & 7-day usage windows · reset countdowns · model health mascots · PIN-encrypted token · web control panel · screen carousel with 7-day chart, Anthropic news & clock (✨ Dust, v3)*
 
@@ -48,7 +48,7 @@ A standalone desk gadget that polls the Anthropic API and shows your Claude Code
 
 ### ⚡ Flash it from your browser
 
-**[oauramos.github.io/claude-usage-stick](https://oauramos.github.io/claude-usage-stick/)** — pick your board, plug it in over USB-C, hit Flash. Nothing to install; Chrome or Edge on desktop.
+**[oauramos.github.io/claude-usage-stick](https://oauramos.github.io/claude-usage-stick/)** — pick your board, plug it in over USB-C, hit Flash. Nothing to install; any desktop browser with Web Serial — Chrome, Edge, Opera, or Firefox 151+.
 
 ### Or build from source
 

--- a/web/index.html
+++ b/web/index.html
@@ -1039,7 +1039,7 @@
           <span class="bolt">⚡</span><span id="flashBtnLabel">Select a board above</span>
         </button>
         <div class="flash-notes">
-          <span><i class="dot"></i>Chrome or Edge on desktop</span>
+          <span><i class="dot"></i>Chrome, Edge or Firefox</span>
           <span><i class="dot"></i>any USB-C data cable</span>
           <span><i class="dot"></i>takes about 2 minutes</span>
           <span><i class="dot"></i>nothing is uploaded — the firmware flows browser → board</span>
@@ -1124,7 +1124,7 @@
     <div class="dlg-actions">
       <esp-web-install-button id="espInstall">
         <button class="btn-primary" slot="activate">Connect &amp; flash</button>
-        <span class="dlg-unsup" slot="unsupported">Web Serial isn't available in this browser — use Chrome or Edge on desktop.</span>
+        <span class="dlg-unsup" slot="unsupported">Web Serial isn't available in this browser — use Chrome, Edge, Opera, or Firefox 151+ on desktop.</span>
         <span class="dlg-unsup" slot="not-allowed">Flashing needs a secure (HTTPS) page.</span>
       </esp-web-install-button>
       <button class="btn-ghost" id="dlgCancel">Cancel</button>

--- a/web/src/build.py
+++ b/web/src/build.py
@@ -186,7 +186,7 @@ MOCK_ACTIONS = '''    <div class="dlg-actions">
 REAL_ACTIONS = '''    <div class="dlg-actions">
       <esp-web-install-button id="espInstall">
         <button class="btn-primary" slot="activate">Connect &amp; flash</button>
-        <span class="dlg-unsup" slot="unsupported">Web Serial isn't available in this browser — use Chrome or Edge on desktop.</span>
+        <span class="dlg-unsup" slot="unsupported">Web Serial isn't available in this browser — use Chrome, Edge, Opera, or Firefox 151+ on desktop.</span>
         <span class="dlg-unsup" slot="not-allowed">Flashing needs a secure (HTTPS) page.</span>
       </esp-web-install-button>
       <button class="btn-ghost" id="dlgCancel">Cancel</button>

--- a/web/src/template.html
+++ b/web/src/template.html
@@ -871,7 +871,7 @@
           <span class="bolt">⚡</span><span id="flashBtnLabel">Select a board above</span>
         </button>
         <div class="flash-notes">
-          <span><i class="dot"></i>Chrome or Edge on desktop</span>
+          <span><i class="dot"></i>Chrome, Edge or Firefox</span>
           <span><i class="dot"></i>any USB-C data cable</span>
           <span><i class="dot"></i>takes about 2 minutes</span>
           <span><i class="dot"></i>nothing is uploaded — the firmware flows browser → board</span>

--- a/wiki/CrowPanel-Advance-35.md
+++ b/wiki/CrowPanel-Advance-35.md
@@ -18,7 +18,7 @@ Part of [Claude Usage Stick](Home). The biggest screen in the lineup — a 3.5" 
 
 ## Flash
 
-Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, pick this board, and plug it in over USB-C.
 
 From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 

--- a/wiki/ESP32-C3-OLED.md
+++ b/wiki/ESP32-C3-OLED.md
@@ -20,7 +20,7 @@ Part of [Claude Usage Stick](Home). The smallest and cheapest way to run the fir
 
 ## Flash
 
-Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, pick this board, and plug it in over USB-C.
 
 From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 

--- a/wiki/Flashing.md
+++ b/wiki/Flashing.md
@@ -8,7 +8,7 @@ Open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)**, pick
 
 Requirements:
 
-- **Chrome, Edge, or Opera on desktop.** The flasher uses the Web Serial API, which Firefox, Safari, and every browser on iOS/Android do not implement.
+- **A browser with Web Serial:** Chrome, Edge or Opera (89+), **Firefox 151+**, or Chrome on Android (138+). Safari doesn't implement it, and neither does any browser on iOS.
 - **A USB-C data cable.** Charge-only cables power the board but carry no data.
 - If the board isn't detected, hold **BOOT** while plugging it in to force download mode.
 

--- a/wiki/Home.md
+++ b/wiki/Home.md
@@ -15,7 +15,7 @@ A standalone desk gadget that polls the Anthropic API and shows your rate-limit 
 | **Just flashed it?** | [Setup and daily use](Setup-and-Daily-Use) |
 | **Something's wrong?** | [Troubleshooting](Troubleshooting) |
 
-The fastest path to a working device: pick a board from the [supported list](Supported-Boards), open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, and plug the board in over USB-C. No toolchain, no drivers, no clone.
+The fastest path to a working device: pick a board from the [supported list](Supported-Boards), open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, and plug the board in over USB-C. No toolchain, no drivers, no clone.
 
 ## All pages
 

--- a/wiki/LilyGo-T-Display-S3-AMOLED.md
+++ b/wiki/LilyGo-T-Display-S3-AMOLED.md
@@ -17,7 +17,7 @@ Part of [Claude Usage Stick](Home). The AMOLED variant of the T-Display S3 — a
 
 ## Flash
 
-Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, pick this board, and plug it in over USB-C.
 
 From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 

--- a/wiki/LilyGo-T-Display-S3.md
+++ b/wiki/LilyGo-T-Display-S3.md
@@ -16,7 +16,7 @@ Part of [Claude Usage Stick](Home). The biggest small-format screen in the lineu
 
 ## Flash
 
-Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, pick this board, and plug it in over USB-C.
 
 From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 

--- a/wiki/LilyGo-T8-ESP32-S2.md
+++ b/wiki/LilyGo-T8-ESP32-S2.md
@@ -17,7 +17,7 @@ Part of [Claude Usage Stick](Home). A bare-bones ESP32-S2 board with the same 1.
 
 ## Flash
 
-Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, pick this board, and plug it in over USB-C.
 
 From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 

--- a/wiki/M5StickC-Plus.md
+++ b/wiki/M5StickC-Plus.md
@@ -16,7 +16,7 @@ Part of [Claude Usage Stick](Home). The original board this project was built fo
 
 ## Flash
 
-Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, pick this board, and plug it in over USB-C.
 
 From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 

--- a/wiki/M5StickC-Plus2.md
+++ b/wiki/M5StickC-Plus2.md
@@ -16,7 +16,7 @@ Part of [Claude Usage Stick](Home). The successor to the M5StickC Plus — same 
 
 ## Flash
 
-Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, pick this board, and plug it in over USB-C.
 
 From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 

--- a/wiki/TTGO-T-Display-ESP32.md
+++ b/wiki/TTGO-T-Display-ESP32.md
@@ -16,7 +16,7 @@ Part of [Claude Usage Stick](Home). The classic LilyGo/TTGO T-Display — an ori
 
 ## Flash
 
-Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome or Edge, pick this board, and plug it in over USB-C.
+Easiest: open the **[web flasher](https://oauramos.github.io/claude-usage-stick/)** in Chrome, Edge or Firefox, pick this board, and plug it in over USB-C.
 
 From source, with the [PlatformIO CLI](https://platformio.org/install/cli):
 

--- a/wiki/Troubleshooting.md
+++ b/wiki/Troubleshooting.md
@@ -4,7 +4,9 @@
 
 ### The web flasher doesn't show a Connect button
 
-Web Serial only exists in **Chrome, Edge, and Opera on desktop**. Firefox and Safari don't implement it, and neither does any browser on iOS or Android. The page will say so rather than failing silently.
+The flasher needs the Web Serial API: **Chrome, Edge or Opera (89+), Firefox 151+**, or **Chrome on Android (138+)**. Safari doesn't implement it on any platform, and neither does Firefox for Android. The page says so rather than failing silently.
+
+If your Firefox is older than 151, update it — Web Serial landed there recently, and older builds genuinely can't flash.
 
 ### The board isn't in the serial-port list
 


### PR DESCRIPTION
**Firefox works.** Firefox 151 shipped the Web Serial API, so the web flasher runs there — our docs asserted the opposite everywhere. Verified two ways: a real Firefox 153 reports a working `navigator.serial` (`requestPort`, `getPorts`, `Serial` prototype), and MDN's compat data lists `firefox: 151`.

While checking, the same data showed **Chrome for Android 138+** also supports it — so the "no browser on iOS or Android" line was wrong too. Safari (all platforms) and Firefox for Android still don't implement it.

Corrected in: README (both mentions), the flasher page's requirement chip and its unsupported-browser message, `Flashing`, `Troubleshooting`, `Home`, and all eight board pages.

**CTA**: the hero link drops the `>>>> <<<<` arrows — same size and prominence, without the shareware tone.